### PR TITLE
Update README for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ your platform before using pion-WebRTC.
 `sudo apt-get install libssl-dev`
 
 #### OSX
-`brew install openssl`
+
+```
+brew install openssl
+export CPATH=`brew --prefix`/opt/openssl/include
+export LIBRARY_PATH=`brew --prefix`/opt/openssl/lib
+go get -u github.com/pions/webrtc
+```
 
 #### Fedora
 `sudo yum install openssl-devel`


### PR DESCRIPTION
Document necessary environment variables for macOS for `go get` to succeed.

Without these, `go get` will fail, even if `openssl` is installed:

```
$ go get -u github.com/pions/webrtc
# github.com/pions/webrtc/internal/dtls
In file included from ../../pions/webrtc/internal/dtls/dtls.go:10:
./dtls.h:4:10: fatal error: 'openssl/bio.h' file not found
#include <openssl/bio.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```