### PR TITLE
add RTCConfiguration and RTCPeerConnection constructor

### DIFF
--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -29,7 +29,7 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection := &webrtc.RTCPeerConnection{}
+	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
 
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
 	// for the given codec

--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -29,7 +29,10 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	if err != nil {
+		panic(err)
+	}
 
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
 	// for the given codec

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -28,7 +28,10 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	if err != nil {
+		panic(err)
+	}
 
 	// Create a audio track
 	opusIn, err := peerConnection.AddTrack(webrtc.Opus, 48000)

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -28,7 +28,7 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection := &webrtc.RTCPeerConnection{}
+	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
 
 	// Create a audio track
 	opusIn, err := peerConnection.AddTrack(webrtc.Opus, 48000)

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -27,7 +27,7 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection := &webrtc.RTCPeerConnection{}
+	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
 
 	// Set a handler for when a new remote track starts, this handler saves buffers to disk as
 	// an ivf file, since we could have multiple video tracks we provide a counter.

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -27,7 +27,10 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, _ := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	if err != nil {
+		panic(err)
+	}
 
 	// Set a handler for when a new remote track starts, this handler saves buffers to disk as
 	// an ivf file, since we could have multiple video tracks we provide a counter.

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -1,0 +1,50 @@
+package webrtc
+
+import "strings"
+
+// RTCCredentialType specifies the type of credentials provided
+type RTCCredentialType string
+
+var (
+	// RTCCredentialTypePassword describes username+pasword based credentials
+	RTCCredentialTypePassword RTCCredentialType = "password"
+	// RTCCredentialTypeToken describes token based credentials
+	RTCCredentialTypeToken RTCCredentialType = "token"
+)
+
+// RTCServerType is used to identify different ICE server types
+type RTCServerType string
+
+var (
+	// RTCServerTypeSTUN is used to identify STUN servers. Prefix is stun:
+	RTCServerTypeSTUN RTCServerType = "STUN"
+	// RTCServerTypeTURN is used to identify TURN servers. Prefix is turn:
+	RTCServerTypeTURN RTCServerType = "TURN"
+	// RTCServerTypeUnknown is used when an ICE server can not be identified properly.
+	RTCServerTypeUnknown RTCServerType = "UnknownType"
+)
+
+// RTCICEServer describes a single ICE server, as well as required credentials
+type RTCICEServer struct {
+	CredentialType RTCCredentialType
+	URLs           []string
+	Username       string
+	Credential     string
+}
+
+func (c RTCICEServer) serverType() RTCServerType {
+	for _, url := range c.URLs {
+		if strings.HasPrefix(url, "stun:") {
+			return RTCServerTypeSTUN
+		}
+		if strings.HasPrefix(url, "turn:") {
+			return RTCServerTypeTURN
+		}
+	}
+	return RTCServerTypeUnknown
+}
+
+// RTCConfiguration contains RTCPeerConfiguration options
+type RTCConfiguration struct {
+	ICEServers []RTCICEServer // An array of RTCIceServer objects, each describing one server which may be used by the ICE agent; these are typically STUN and/or TURN servers. If this isn't specified, the ICE agent may choose to use its own ICE servers; otherwise, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.
+}

--- a/rtcconfiguration_test.go
+++ b/rtcconfiguration_test.go
@@ -1,0 +1,20 @@
+package webrtc
+
+import "testing"
+
+func TestRTCICEServer_isStun(t *testing.T) {
+	testCases := []struct {
+		expectedType RTCServerType
+		server       RTCICEServer
+	}{
+		{RTCServerTypeSTUN, RTCICEServer{URLs: []string{"stun:google.de"}}},
+		{RTCServerTypeTURN, RTCICEServer{URLs: []string{"turn:google.de"}}},
+		{RTCServerTypeUnknown, RTCICEServer{URLs: []string{"google.de"}}},
+	}
+
+	for _, testCase := range testCases {
+		if serverType := testCase.server.serverType(); serverType != testCase.expectedType {
+			t.Errorf("Expected %q to be %s, but got %s", testCase.server.URLs, testCase.expectedType, serverType)
+		}
+	}
+}

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -122,13 +122,15 @@ func (r *RTCPeerConnection) CreateAnswer() error {
 		basePriority = basePriority + 1
 		r.ports = append(r.ports, port)
 	}
-	for id, server := range r.config.ICEServers {
-		if server.serverType() != RTCServerTypeSTUN {
-			continue
+	if r.config != nil {
+		for id, server := range r.config.ICEServers {
+			if server.serverType() != RTCServerTypeSTUN {
+				continue
+			}
+			// TODO connect to STUN server
+			_ = id
+			_ = server
 		}
-		// TODO connect to STUN server
-		_ = id
-		_ = server
 	}
 
 	r.LocalDescription = sdp.BaseSessionDescription(&sdp.SessionBuilder{

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -3,7 +3,6 @@ package webrtc
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 	"sync"
 	"time"
 
@@ -52,38 +51,6 @@ func (t TrackType) String() string {
 	default:
 		return "Unknown"
 	}
-}
-
-// RTCCredentialType specifies the type of credentials provided
-type RTCCredentialType string
-
-var (
-	// RTCCredentialTypePassword describes username+pasword based credentials
-	RTCCredentialTypePassword RTCCredentialType = "password"
-	// RTCCredentialTypeToken describes token based credentials
-	RTCCredentialTypeToken RTCCredentialType = "token"
-)
-
-// RTCICEServer describes a single ICE server, as well as required credentials
-type RTCICEServer struct {
-	CredentialType RTCCredentialType
-	URLs           []string
-	Username       string
-	Credential     string
-}
-
-func (c RTCICEServer) isSTUN() bool {
-	for _, url := range c.URLs {
-		if strings.HasPrefix(url, "stun:") {
-			return true
-		}
-	}
-	return false
-}
-
-// RTCConfiguration contains RTCPeerConfiguration options
-type RTCConfiguration struct {
-	ICEServers []RTCICEServer // An array of RTCIceServer objects, each describing one server which may be used by the ICE agent; these are typically STUN and/or TURN servers. If this isn't specified, the ICE agent may choose to use its own ICE servers; otherwise, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.
 }
 
 // New creates a new RTCPeerConfiguration with the provided configuration
@@ -154,6 +121,14 @@ func (r *RTCPeerConnection) CreateAnswer() error {
 		candidates = append(candidates, fmt.Sprintf("candidate:udpcandidate %d udp %d %s %d typ host", id+1, basePriority, c, port.ListeningAddr.Port))
 		basePriority = basePriority + 1
 		r.ports = append(r.ports, port)
+	}
+	for id, server := range r.config.ICEServers {
+		if server.serverType() != RTCServerTypeSTUN {
+			continue
+		}
+		// TODO connect to STUN server
+		_ = id
+		_ = server
 	}
 
 	r.LocalDescription = sdp.BaseSessionDescription(&sdp.SessionBuilder{


### PR DESCRIPTION
This PR lays the foundation to get a `RTCConfiguration` object into the library without compromising local/ remote functionality. 