### PR TITLE
basic STUN support

### DIFF
--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -29,7 +29,13 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{
+		ICEServers: []webrtc.RTCICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -28,7 +28,13 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{
+		ICEServers: []webrtc.RTCICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -27,7 +27,13 @@ func main() {
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{})
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{
+		ICEServers: []webrtc.RTCICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/examples/stun/main.go
+++ b/examples/stun/main.go
@@ -1,13 +1,29 @@
 package main
 
 import (
+	"bufio"
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	"github.com/pions/webrtc"
+	"github.com/pions/webrtc/pkg/ice"
+	"github.com/pions/webrtc/pkg/rtp"
 )
 
 func main() {
+	reader := bufio.NewReader(os.Stdin)
+	rawSd, err := reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("")
+	sd, err := base64.StdEncoding.DecodeString(rawSd)
+	if err != nil {
+		panic(err)
+	}
+
 	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{
 		ICEServers: []webrtc.RTCICEServer{
 			{
@@ -16,6 +32,18 @@ func main() {
 		},
 	})
 	if err != nil {
+		panic(err)
+	}
+
+	peerConnection.Ontrack = func(mediaType webrtc.TrackType, packets <-chan *rtp.Packet) {
+		fmt.Printf("Got a %s track\n", mediaType)
+	}
+
+	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+		fmt.Printf("Connection State has changed %s \n", connectionState.String())
+	}
+
+	if err := peerConnection.SetRemoteDescription(string(sd)); err != nil {
 		panic(err)
 	}
 

--- a/examples/stun/main.go
+++ b/examples/stun/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/pions/webrtc"
+)
+
+func main() {
+	peerConnection, err := webrtc.New(&webrtc.RTCConfiguration{
+		ICEServers: []webrtc.RTCICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	if err := peerConnection.CreateAnswer(); err != nil {
+		panic(err)
+	}
+
+	localDescriptionStr := peerConnection.LocalDescription.Marshal()
+	fmt.Println(base64.StdEncoding.EncodeToString([]byte(localDescriptionStr)))
+	select {}
+}

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -1,6 +1,9 @@
 package webrtc
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // RTCCredentialType specifies the type of credentials provided
 type RTCCredentialType string
@@ -32,19 +35,40 @@ type RTCICEServer struct {
 	Credential     string
 }
 
+const (
+	stunPrefix  = "stun:"
+	stunsPrefix = "stuns:"
+	turnPrefix  = "turn:"
+	turnsPrefix = "turns:"
+)
+
 func (c RTCICEServer) serverType() RTCServerType {
 	for _, url := range c.URLs {
-		if strings.HasPrefix(url, "stun:") {
+		if strings.HasPrefix(url, stunPrefix) || strings.HasPrefix(url, stunsPrefix) {
 			return RTCServerTypeSTUN
 		}
-		if strings.HasPrefix(url, "turn:") {
+		if strings.HasPrefix(url, turnPrefix) || strings.HasPrefix(url, turnsPrefix) {
 			return RTCServerTypeTURN
 		}
 	}
 	return RTCServerTypeUnknown
 }
 
+func protocolAndHost(url string) (string, string, error) {
+	if strings.HasPrefix(url, stunPrefix) {
+		return "udp", url[len(stunPrefix):], nil
+	}
+	if strings.HasPrefix(url, stunsPrefix) {
+		return "tcp", url[len(stunsPrefix):], nil
+	}
+	// TODO TURN urls
+	return "", "", fmt.Errorf("Unknown protocol in URL %q", url)
+}
+
 // RTCConfiguration contains RTCPeerConfiguration options
 type RTCConfiguration struct {
-	ICEServers []RTCICEServer // An array of RTCIceServer objects, each describing one server which may be used by the ICE agent; these are typically STUN and/or TURN servers. If this isn't specified, the ICE agent may choose to use its own ICE servers; otherwise, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.
+	// ICEServers holds multiple RTCICEServer instances, each describing one server which may be used by the ICE agent;
+	// these are typically STUN and/or TURN servers. If this isn't specified, the ICE agent may choose to use its own ICE servers;
+	// otherwise, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.
+	ICEServers []RTCICEServer
 }

--- a/rtcconfiguration_test.go
+++ b/rtcconfiguration_test.go
@@ -18,3 +18,27 @@ func TestRTCICEServer_isStun(t *testing.T) {
 		}
 	}
 }
+
+func TestPortAndHost(t *testing.T) {
+	testCases := []struct {
+		url              string
+		expectedHost     string
+		expectedProtocol string
+	}{
+		{"stun:stun.l.google.com:19302", "stun.l.google.com:19302", "udp"},
+		{"stuns:stun.l.google.com:19302", "stun.l.google.com:19302", "tcp"},
+	}
+
+	for _, testCase := range testCases {
+		proto, host, err := protocolAndHost(testCase.url)
+		if err != nil {
+			t.Fatalf("unable to get proto and host: %v", err)
+		}
+		if proto != testCase.expectedProtocol {
+			t.Fatalf("expected %s, got %s", testCase.expectedProtocol, proto)
+		}
+		if host != testCase.expectedHost {
+			t.Fatalf("expected %s, got %s", testCase.expectedHost, host)
+		}
+	}
+}


### PR DESCRIPTION
this PR adds support for modern STUN, as specified in [RFC 5389](https://tools.ietf.org/html/rfc5389). Once merged this will close #18.

Missing is stuns support, as well as automatic end 2 end tests to ensure that this functionality does not break. I'll be working on adding those afterwards.