### PR TITLE
Add extra documentations as well as random re-org to sync with RFC order

### DIFF
--- a/examples/gstreamer-receive/README.md
+++ b/examples/gstreamer-receive/README.md
@@ -14,7 +14,7 @@ go get github.com/pions/webrtc/examples/gstreamer-receive
 ```
 
 ### Open gstreamer-receive example page
-[jsfiddle.net](https://jsfiddle.net/usd3xmtz/2/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/usd3xmtz/35/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run gstreamer-receive with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -2,12 +2,15 @@ package network
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 
 	"github.com/pions/pkg/stun"
 	"github.com/pions/webrtc/internal/dtls"
 	"github.com/pions/webrtc/internal/sctp"
 	"github.com/pions/webrtc/internal/srtp"
+	webrtcStun "github.com/pions/webrtc/internal/stun"
 	"github.com/pions/webrtc/pkg/datachannel"
 	"github.com/pions/webrtc/pkg/ice"
 	"github.com/pions/webrtc/pkg/rtp"
@@ -17,7 +20,7 @@ import (
 // Manager contains all network state (DTLS, SRTP) that is shared between ports
 // It is also used to perform operations that involve multiple ports
 type Manager struct {
-	icePwd      []byte
+	IceAgent    *ice.Agent
 	iceNotifier ICENotifier
 
 	dtlsState *dtls.State
@@ -43,61 +46,9 @@ type Manager struct {
 	ports     []*port
 }
 
-func (m *Manager) dataChannelInboundHandler(data []byte, streamIdentifier uint16, payloadType sctp.PayloadProtocolIdentifier) {
-	switch payloadType {
-	case sctp.PayloadTypeWebRTCDCEP:
-		msg, err := datachannel.Parse(data)
-		if err != nil {
-			fmt.Println(errors.Wrap(err, "Failed to parse DataChannel packet"))
-			return
-		}
-		switch msg := msg.(type) {
-		case *datachannel.ChannelOpen:
-			// Cannot return err
-			ack := datachannel.ChannelAck{}
-			ackMsg, err := ack.Marshal()
-			if err != nil {
-				fmt.Println("Error Marshaling ChannelOpen ACK", err)
-				return
-			}
-			if err = m.sctpAssociation.HandleOutbound(ackMsg, streamIdentifier, sctp.PayloadTypeWebRTCDCEP); err != nil {
-				fmt.Println("Error sending ChannelOpen ACK", err)
-				return
-			}
-			m.dataChannelEventHandler(&DataChannelCreated{streamIdentifier: streamIdentifier, Label: string(msg.Label)})
-		default:
-			fmt.Println("Unhandled DataChannel message", m)
-		}
-	case sctp.PayloadTypeWebRTCString:
-		fallthrough
-	case sctp.PayloadTypeWebRTCStringEmpty:
-		m.dataChannelEventHandler(&DataChannelMessage{streamIdentifier: streamIdentifier, Payload: &datachannel.PayloadString{Data: data}})
-	case sctp.PayloadTypeWebRTCBinary:
-		fallthrough
-	case sctp.PayloadTypeWebRTCBinaryEmpty:
-		m.dataChannelEventHandler(&DataChannelMessage{streamIdentifier: streamIdentifier, Payload: &datachannel.PayloadBinary{Data: data}})
-	default:
-		fmt.Printf("Unhandled Payload Protocol Identifier %v \n", payloadType)
-	}
-}
-
-func (m *Manager) dataChannelOutboundHandler(raw []byte) {
-	m.portsLock.Lock()
-	defer m.portsLock.Unlock()
-
-	for _, p := range m.ports {
-		if p.IceState() == ice.ConnectionStateCompleted {
-			p.sendSCTP(raw)
-			return
-		}
-	}
-
-}
-
 // NewManager creates a new network.Manager
-func NewManager(icePwd []byte, bufferTransportGenerator BufferTransportGenerator, dataChannelEventHandler DataChannelEventHandler, iceNotifier ICENotifier) (m *Manager, err error) {
+func NewManager(bufferTransportGenerator BufferTransportGenerator, dataChannelEventHandler DataChannelEventHandler, iceNotifier ICENotifier) (m *Manager, err error) {
 	m = &Manager{
-		icePwd:                   icePwd,
 		iceNotifier:              iceNotifier,
 		bufferTransports:         make(map[uint32]chan<- *rtp.Packet),
 		srtpContexts:             make(map[string]*srtp.Context),
@@ -111,18 +62,46 @@ func NewManager(icePwd []byte, bufferTransportGenerator BufferTransportGenerator
 
 	m.sctpAssociation = sctp.NewAssocation(m.dataChannelOutboundHandler, m.dataChannelInboundHandler)
 
+	m.IceAgent = ice.NewAgent(m.iceOutboundHandler)
+	for _, i := range localInterfaces() {
+		p, err := newPort(i+":0", m)
+		if err != nil {
+			return nil, err
+		}
+
+		m.ports = append(m.ports, p)
+		m.IceAgent.AddLocalCandidate(&ice.CandidateHost{
+			CandidateBase: ice.CandidateBase{
+				Protocol: ice.TransportUDP,
+				Address:  p.listeningAddr.IP.String(),
+				Port:     p.listeningAddr.Port,
+			},
+		})
+	}
+
 	return m, err
 }
 
-// Listen starts a new Port for this manager
-func (m *Manager) Listen(address string) (boundAddress *stun.TransportAddr, err error) {
-	p, err := newPort(address, m)
-	if err != nil {
-		return nil, err
+// AddURL takes an ICE Url, allocates any state and adds the candidate
+func (m *Manager) AddURL(url *ice.URL) error {
+	switch url.Type {
+	case ice.ServerTypeSTUN:
+		c, err := webrtcStun.Allocate(url)
+		if err != nil {
+			return err
+		}
+		p, err := newPort(c.RemoteAddress+":"+strconv.Itoa(c.RemotePort), m)
+		if err != nil {
+			return err
+		}
+
+		m.ports = append(m.ports, p)
+		m.IceAgent.AddLocalCandidate(c)
+	default:
+		return errors.Errorf("%s is not implemented", url.Type.String())
 	}
 
-	m.ports = append(m.ports, p)
-	return p.listeningAddr, nil
+	return nil
 }
 
 // Close cleans up all the allocated state
@@ -132,12 +111,17 @@ func (m *Manager) Close() {
 
 	err := m.sctpAssociation.Close()
 	m.dtlsState.Close()
-	for _, p := range m.ports {
-		portError := p.close()
-		if err != nil {
-			err = errors.Wrapf(portError, " also: %s", err.Error())
+	m.IceAgent.Close()
+
+	for i := len(m.ports) - 1; i >= 0; i-- {
+		if portError := m.ports[i].close(); portError != nil {
+			if err != nil {
+				err = errors.Wrapf(portError, " also: %s", err.Error())
+			} else {
+				err = portError
+			}
 		} else {
-			err = portError
+			m.ports = append(m.ports[:i], m.ports[i+1:]...)
 		}
 	}
 }
@@ -152,10 +136,13 @@ func (m *Manager) SendRTP(packet *rtp.Packet) {
 	m.portsLock.Lock()
 	defer m.portsLock.Unlock()
 
+	local, remote := m.IceAgent.SelectedPair()
+	if local == nil || remote == nil {
+		return
+	}
 	for _, p := range m.ports {
-		if p.IceState() == ice.ConnectionStateCompleted {
-			p.sendRTP(packet)
-			return
+		if p.listeningAddr.Equal(local) {
+			p.sendRTP(packet, remote)
 		}
 	}
 }
@@ -206,20 +193,67 @@ func (m *Manager) SendDataChannelMessage(payload datachannel.Payload, streamIden
 	return nil
 }
 
-func (m *Manager) iceHandler(newState ice.ConnectionState) {
-	// One port disconnected, scan the other ones
-	if newState == ice.ConnectionStateDisconnected {
-		m.portsLock.Lock()
-		defer m.portsLock.Unlock()
-
-		for _, p := range m.ports {
-			if p.IceState() == ice.ConnectionStateCompleted {
-				// Another peer is connected! We don't have to notify RTCPeerConnection
-				break
-			}
+func (m *Manager) dataChannelInboundHandler(data []byte, streamIdentifier uint16, payloadType sctp.PayloadProtocolIdentifier) {
+	switch payloadType {
+	case sctp.PayloadTypeWebRTCDCEP:
+		msg, err := datachannel.Parse(data)
+		if err != nil {
+			fmt.Println(errors.Wrap(err, "Failed to parse DataChannel packet"))
+			return
 		}
-		m.iceNotifier(newState)
-	} else {
-		m.iceNotifier(newState)
+		switch msg := msg.(type) {
+		case *datachannel.ChannelOpen:
+			// Cannot return err
+			ack := datachannel.ChannelAck{}
+			ackMsg, err := ack.Marshal()
+			if err != nil {
+				fmt.Println("Error Marshaling ChannelOpen ACK", err)
+				return
+			}
+			if err = m.sctpAssociation.HandleOutbound(ackMsg, streamIdentifier, sctp.PayloadTypeWebRTCDCEP); err != nil {
+				fmt.Println("Error sending ChannelOpen ACK", err)
+				return
+			}
+			m.dataChannelEventHandler(&DataChannelCreated{streamIdentifier: streamIdentifier, Label: string(msg.Label)})
+		default:
+			fmt.Println("Unhandled DataChannel message", m)
+		}
+	case sctp.PayloadTypeWebRTCString:
+		fallthrough
+	case sctp.PayloadTypeWebRTCStringEmpty:
+		m.dataChannelEventHandler(&DataChannelMessage{streamIdentifier: streamIdentifier, Payload: &datachannel.PayloadString{Data: data}})
+	case sctp.PayloadTypeWebRTCBinary:
+		fallthrough
+	case sctp.PayloadTypeWebRTCBinaryEmpty:
+		m.dataChannelEventHandler(&DataChannelMessage{streamIdentifier: streamIdentifier, Payload: &datachannel.PayloadBinary{Data: data}})
+	default:
+		fmt.Printf("Unhandled Payload Protocol Identifier %v \n", payloadType)
+	}
+}
+
+func (m *Manager) dataChannelOutboundHandler(raw []byte) {
+	m.portsLock.Lock()
+	defer m.portsLock.Unlock()
+
+	local, remote := m.IceAgent.SelectedPair()
+	if local == nil || remote == nil {
+		return
+	}
+	for _, p := range m.ports {
+		if p.listeningAddr.Equal(local) {
+			p.sendSCTP(raw, remote)
+		}
+	}
+}
+
+func (m *Manager) iceOutboundHandler(raw []byte, local *stun.TransportAddr, remote *net.UDPAddr) {
+	m.portsLock.Lock()
+	defer m.portsLock.Unlock()
+
+	for _, p := range m.ports {
+		if p.listeningAddr == local {
+			p.sendICE(raw, remote)
+			return
+		}
 	}
 }

--- a/internal/network/port-receive.go
+++ b/internal/network/port-receive.go
@@ -5,13 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"time"
 
-	"github.com/pions/pkg/stun"
 	"github.com/pions/webrtc/internal/dtls"
 	"github.com/pions/webrtc/internal/sctp"
 	"github.com/pions/webrtc/internal/srtp"
-	"github.com/pions/webrtc/pkg/ice"
 	"github.com/pions/webrtc/pkg/rtp"
 	"github.com/pkg/errors"
 )
@@ -19,14 +16,6 @@ import (
 type incomingPacket struct {
 	srcAddr *net.UDPAddr
 	buffer  []byte
-}
-
-func (p *port) updateICEAndNotify(newState ice.ConnectionState) {
-	p.iceStateLock.Lock()
-	p.iceState = newState
-	p.iceStateLock.Unlock()
-
-	p.m.iceHandler(p.iceState)
 }
 
 func (p *port) handleSRTP(buffer []byte) {
@@ -94,29 +83,6 @@ func (p *port) handleSRTP(buffer []byte) {
 
 }
 
-func (p *port) handleICE(in *incomingPacket, iceTimer *time.Timer) {
-	if m, err := stun.NewMessage(in.buffer); err == nil && m.Class == stun.ClassRequest && m.Method == stun.MethodBinding {
-		dstAddr := &stun.TransportAddr{IP: in.srcAddr.IP, Port: in.srcAddr.Port}
-		if err := stun.BuildAndSend(p.conn, dstAddr, stun.ClassSuccessResponse, stun.MethodBinding, m.TransactionID,
-			&stun.XorMappedAddress{
-				XorAddress: stun.XorAddress{
-					IP:   dstAddr.IP,
-					Port: dstAddr.Port,
-				},
-			},
-			&stun.MessageIntegrity{
-				Key: p.m.icePwd,
-			},
-			&stun.Fingerprint{},
-		); err != nil {
-			fmt.Println(err)
-		} else {
-			p.updateICEAndNotify(ice.ConnectionStateCompleted)
-			iceTimer.Reset(iceTimeout)
-		}
-	}
-}
-
 func (p *port) handleSCTP(raw []byte, a *sctp.Association) {
 	p.m.sctpAssociation.Lock()
 	defer p.m.sctpAssociation.Unlock()
@@ -139,8 +105,6 @@ func (p *port) handleDTLS(raw []byte, srcAddr string) {
 
 }
 
-const iceTimeout = time.Second * 10
-const noTimeout = time.Hour * 8760
 const receiveMTU = 8192
 
 func (p *port) networkLoop() {
@@ -164,13 +128,8 @@ func (p *port) networkLoop() {
 		}
 	}()
 
-	// Never timeout originally, only start timer after we get an ICE ping
-	iceTimer := time.NewTimer(noTimeout)
 	for {
 		select {
-		case <-iceTimer.C:
-			p.updateICEAndNotify(ice.ConnectionStateDisconnected)
-			iceTimer.Reset(noTimeout)
 		case in, socketOpen := <-incomingPackets:
 			if !socketOpen {
 				// incomingPackets channel has closed, this port is finished processing
@@ -183,26 +142,22 @@ func (p *port) networkLoop() {
 				continue
 			}
 
-			// TODO these should age out, a candidate might not be good forever
-			p.seenPeersLock.Lock()
-			p.seenPeers[in.srcAddr.String()] = in.srcAddr
-			p.seenPeersLock.Unlock()
-
 			// https://tools.ietf.org/html/rfc5764#page-14
 			if 127 < in.buffer[0] && in.buffer[0] < 192 {
 				p.handleSRTP(in.buffer)
 			} else if 19 < in.buffer[0] && in.buffer[0] < 64 {
 				p.handleDTLS(in.buffer, in.srcAddr.String())
 			} else if in.buffer[0] < 2 {
-				p.handleICE(in, iceTimer)
+				p.m.IceAgent.HandleInbound(in.buffer, p.listeningAddr, in.srcAddr)
 			}
 
+			// TODO should use SetupAttr
+			// Currently we always send a DoHandshake (which seems to work ok)
 			p.m.certPairLock.RLock()
 			if p.m.certPair == nil {
 				p.m.dtlsState.DoHandshake(p.listeningAddr.String(), in.srcAddr.String())
 			}
 			p.m.certPairLock.RUnlock()
-
 		}
 	}
 }

--- a/internal/network/port-send.go
+++ b/internal/network/port-send.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pions/webrtc/pkg/rtp"
 )
 
-func (p *port) sendRTP(packet *rtp.Packet) {
+func (p *port) sendRTP(packet *rtp.Packet, dst *net.UDPAddr) {
 	p.m.certPairLock.RLock()
 	defer p.m.certPairLock.RUnlock()
 	if p.m.certPair == nil {
@@ -16,20 +16,7 @@ func (p *port) sendRTP(packet *rtp.Packet) {
 		return
 	}
 
-	var peer *net.UDPAddr
-	p.seenPeersLock.RLock()
-	for _, p := range p.seenPeers {
-		peer = p
-		break
-	}
-	p.seenPeersLock.RUnlock()
-
-	if peer == nil {
-		fmt.Printf("No peers to send to, ICE state is %s \n", p.iceState.String())
-		return
-	}
-
-	contextMapKey := peer.String() + ":" + fmt.Sprint(packet.SSRC)
+	contextMapKey := dst.String() + ":" + fmt.Sprint(packet.SSRC)
 	p.m.srtpContextsLock.Lock()
 	srtpContext, ok := p.m.srtpContexts[contextMapKey]
 	if !ok {
@@ -49,7 +36,7 @@ func (p *port) sendRTP(packet *rtp.Packet) {
 		if err != nil {
 			fmt.Printf("Failed to marshal packet: %s \n", err.Error())
 		}
-		if _, err := p.conn.WriteTo(raw, nil, peer); err != nil {
+		if _, err := p.conn.WriteTo(raw, nil, dst); err != nil {
 			fmt.Printf("Failed to send packet: %s \n", err.Error())
 		}
 	} else {
@@ -57,20 +44,12 @@ func (p *port) sendRTP(packet *rtp.Packet) {
 	}
 }
 
-func (p *port) sendSCTP(buf []byte) {
-	var peer *net.UDPAddr
-
-	p.seenPeersLock.RLock()
-	for _, p := range p.seenPeers {
-		peer = p
-		break
+func (p *port) sendICE(buf []byte, dst *net.UDPAddr) {
+	if _, err := p.conn.WriteTo(buf, nil, dst); err != nil {
+		fmt.Printf("Failed to send packet: %s \n", err.Error())
 	}
-	p.seenPeersLock.RUnlock()
+}
 
-	if peer == nil {
-		fmt.Printf("No peers to send to, ICE state is %s \n", p.iceState.String())
-		return
-	}
-
-	p.m.dtlsState.Send(buf, p.listeningAddr.String(), peer.String())
+func (p *port) sendSCTP(buf []byte, dst *net.UDPAddr) {
+	p.m.dtlsState.Send(buf, p.listeningAddr.String(), dst.String())
 }

--- a/internal/network/port.go
+++ b/internal/network/port.go
@@ -2,23 +2,15 @@ package network
 
 import (
 	"net"
-	"sync"
 
 	"github.com/pions/pkg/stun"
 	"github.com/pions/webrtc/internal/dtls"
-	"github.com/pions/webrtc/pkg/ice"
 	"golang.org/x/net/ipv4"
 )
 
 type port struct {
-	iceStateLock sync.RWMutex
-	iceState     ice.ConnectionState
-
 	conn          *ipv4.PacketConn
 	listeningAddr *stun.TransportAddr
-
-	seenPeers     map[string]*net.UDPAddr
-	seenPeersLock sync.RWMutex
 
 	m *Manager
 }
@@ -41,8 +33,6 @@ func newPort(address string, m *Manager) (*port, error) {
 		listeningAddr: addr,
 		conn:          conn,
 		m:             m,
-		seenPeers:     make(map[string]*net.UDPAddr),
-		iceState:      ice.ConnectionStateNew,
 	}
 
 	go p.networkLoop()
@@ -51,10 +41,4 @@ func newPort(address string, m *Manager) (*port, error) {
 
 func (p *port) close() error {
 	return p.conn.Close()
-}
-
-func (p *port) IceState() ice.ConnectionState {
-	p.iceStateLock.RLock()
-	defer p.iceStateLock.RUnlock()
-	return p.iceState
 }

--- a/internal/network/util.go
+++ b/internal/network/util.go
@@ -1,0 +1,41 @@
+package network
+
+import "net"
+
+func localInterfaces() (ips []string) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ips
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return ips
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue // not an ipv4 address
+			}
+			ips = append(ips, ip.String())
+		}
+	}
+	return ips
+}

--- a/internal/sdp/ice.go
+++ b/internal/sdp/ice.go
@@ -1,0 +1,51 @@
+package sdp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pions/webrtc/pkg/ice"
+)
+
+// ICECandidateBuild takes a candidate strings and returns a ice.Candidate or nil if it fails to parse
+func ICECandidateBuild(raw string) ice.Candidate {
+	split := strings.Fields(raw)
+	if len(split) < 8 {
+		fmt.Printf("Attribute not long enough to be ICE candidate (%d) %s \n", len(split), raw)
+		return nil
+	}
+
+	getValue := func(key string) string {
+		rtrnNext := false
+		for _, i := range split {
+			if rtrnNext {
+				return i
+			} else if i == key {
+				rtrnNext = true
+			}
+		}
+		return ""
+	}
+
+	port, err := strconv.Atoi(split[5])
+	if err != nil {
+		return nil
+	}
+
+	// TODO verify valid address
+	address := split[4]
+
+	switch getValue("typ") {
+	case "host":
+		return &ice.CandidateHost{
+			CandidateBase: ice.CandidateBase{
+				Protocol: ice.TransportUDP,
+				Address:  address,
+				Port:     port,
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/internal/sdp/jsep.go
+++ b/internal/sdp/jsep.go
@@ -128,8 +128,6 @@ func (d *MediaDescription) WithMediaSource(ssrc uint32, cname, streamLabel, labe
 }
 
 // WithCandidate adds an ICE candidate to the media description
-func (d *MediaDescription) WithCandidate(id int, transport string, basePriority uint16, ip string, port int, typ string) *MediaDescription {
-	return d.
-		WithValueAttribute("candidate",
-			fmt.Sprintf("%scandidate %d %s %d %s %d typ %s", transport, id, transport, basePriority, ip, port, typ))
+func (d *MediaDescription) WithCandidate(value string) *MediaDescription {
+	return d.WithValueAttribute("candidate", value)
 }

--- a/internal/sdp/session_description.go
+++ b/internal/sdp/session_description.go
@@ -66,19 +66,19 @@ type SessionDescription struct {
 
 	// EncryptionKeys if for when the SessionDescription is transported over a secure and trusted channel,
 	// the Session Description Protocol MAY be used to convey encryption keys
-	// https://tools.ietf.org/html/rfc4566#section-5.11
+	// https://tools.ietf.org/html/rfc4566#section-5.12
 	EncryptionKeys []string
 
 	// Attributes are the primary means for extending SDP.  Attributes may
 	// be defined to be used as "session-level" attributes, "media-level"
 	// attributes, or both.
-	// https://tools.ietf.org/html/rfc4566#section-5.12
+	// https://tools.ietf.org/html/rfc4566#section-5.13
 	Attributes []string
 
 	// MediaDescriptions A session description may contain a number of media descriptions.
 	// Each media description starts with an "m=" field and is terminated by
 	// either the next "m=" field or by the end of the session description.
-	// https://tools.ietf.org/html/rfc4566#section-5.13
+	// https://tools.ietf.org/html/rfc4566#section-5.14
 	MediaDescriptions []*MediaDescription
 }
 

--- a/internal/stun/stun.go
+++ b/internal/stun/stun.go
@@ -1,0 +1,55 @@
+package stun
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/pions/pkg/stun"
+	"github.com/pions/webrtc/pkg/ice"
+	"github.com/pkg/errors"
+)
+
+// Allocate crafts and sends a STUN binding
+// On success will return our XORMappedAddress
+func Allocate(url *ice.URL) (*ice.CandidateSrflx, error) {
+	// TODO Do we want the timeout to be configurable?
+	proto := url.TransportType.String()
+	client, err := stun.NewClient(proto, fmt.Sprintf("%s:%d", url.Host, url.Port), time.Second*5)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create STUN client")
+	}
+	localAddr, ok := client.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil, errors.Errorf("Failed to cast STUN client to UDPAddr")
+	}
+
+	resp, err := client.Request()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to make STUN request")
+	}
+
+	if err = client.Close(); err != nil {
+		return nil, errors.Wrapf(err, "Failed to close STUN client")
+	}
+
+	attr, ok := resp.GetOneAttribute(stun.AttrXORMappedAddress)
+	if !ok {
+		return nil, errors.Errorf("Got respond from STUN server that did not contain XORAddress")
+	}
+
+	var addr stun.XorAddress
+	if err = addr.Unpack(resp, attr); err != nil {
+		return nil, errors.Wrapf(err, "Failed to unpack STUN XorAddress response")
+	}
+
+	return &ice.CandidateSrflx{
+		CandidateBase: ice.CandidateBase{
+			Protocol: ice.TransportUDP,
+			Address:  addr.IP.String(),
+			Port:     addr.Port,
+		},
+		RemoteAddress: localAddr.IP.String(),
+		RemotePort:    localAddr.Port,
+	}, nil
+}

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -1,23 +1,242 @@
 package ice
 
-import "github.com/pions/webrtc/internal/util"
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pions/pkg/stun"
+	"github.com/pions/webrtc/internal/util"
+)
+
+// OutboundCallback is the user defined Callback that is called when ICE traffic needs to sent
+type OutboundCallback func(raw []byte, local *stun.TransportAddr, remote *net.UDPAddr)
 
 // Agent represents the ICE agent
 type Agent struct {
-	Servers [][]URL
-	Ufrag   string
-	Pwd     string
-}
+	sync.RWMutex
 
-// NewAgent creates a new Agent
-func NewAgent() *Agent {
-	return &Agent{
-		Ufrag: util.RandSeq(16),
-		Pwd:   util.RandSeq(32),
+	outboundCallback OutboundCallback
+
+	tieBreaker      uint32
+	connectionState ConnectionState
+	gatheringState  GatheringState
+
+	haveStarted   bool
+	isControlling bool
+	taskLoopChan  chan bool
+
+	LocalUfrag      string
+	LocalPwd        string
+	localCandidates []Candidate
+
+	remoteUfrag      string
+	remotePwd        string
+	remoteCandidates []Candidate
+
+	selectedPair struct {
+		// lastUpdateTime ?
+		remote Candidate
+		local  Candidate
 	}
 }
 
-// SetServers is used to set the ICE servers used by the Agent
-func (a *Agent) SetServers(urls [][]URL) {
-	a.Servers = urls
+const (
+	agentTickerBaseInterval = 20 * time.Millisecond
+)
+
+// NewAgent creates a new Agent
+func NewAgent(outboundCallback OutboundCallback) *Agent {
+	a := &Agent{
+		tieBreaker:       rand.Uint32(),
+		outboundCallback: outboundCallback,
+
+		LocalUfrag: util.RandSeq(16),
+		LocalPwd:   util.RandSeq(32),
+	}
+	if a.isControlling {
+	}
+	return a
+}
+
+// Start starts the agent
+func (a *Agent) Start(isControlling bool) {
+	a.Lock()
+	defer a.Unlock()
+
+	if a.haveStarted {
+		panic("Attempted to start agent twice")
+	}
+
+	a.isControlling = isControlling
+	if isControlling {
+		go a.agentControllingTaskLoop()
+	}
+}
+
+func (a *Agent) pingAllCandidates() {
+	for _, localCandidate := range a.localCandidates {
+		for _, remoteCandidate := range a.remoteCandidates {
+			// Send an ICE ping
+			fmt.Println(localCandidate)
+			fmt.Println(remoteCandidate)
+		}
+	}
+
+}
+
+func (a *Agent) agentControllingTaskLoop() {
+	// TODO this should be dynamic, and grow when the connection is stable
+	t := time.NewTicker(agentTickerBaseInterval)
+
+	for {
+		select {
+		case <-t.C:
+			a.Lock()
+			if a.selectedPair.remote == nil || a.selectedPair.local == nil {
+				a.pingAllCandidates()
+			} else {
+				fmt.Println("Check + Ping selected pair")
+			}
+			a.Unlock()
+		case <-a.taskLoopChan:
+			t.Stop()
+			return
+		}
+	}
+}
+
+// AddRemoteCandidate adds a new remote candidate
+func (a *Agent) AddRemoteCandidate(c Candidate) {
+	a.Lock()
+	defer a.Unlock()
+	a.remoteCandidates = append(a.remoteCandidates, c)
+}
+
+// AddLocalCandidate adds a new local candidate
+func (a *Agent) AddLocalCandidate(c Candidate) {
+	a.Lock()
+	defer a.Unlock()
+	a.localCandidates = append(a.localCandidates, c)
+}
+
+// Close cleans up the Agent
+func (a *Agent) Close() {
+	close(a.taskLoopChan)
+}
+
+// LocalCandidates generates the string representation of the
+// local candidates that can be used in the SDP
+func (a *Agent) LocalCandidates() (rtrn []string) {
+	a.Lock()
+	defer a.Unlock()
+
+	for _, c := range a.localCandidates {
+		rtrn = append(rtrn, c.String(1))
+		rtrn = append(rtrn, c.String(2))
+	}
+	return rtrn
+}
+
+func getTransportAddrCandidate(candidates []Candidate, addr *stun.TransportAddr) Candidate {
+	for _, c := range candidates {
+		if c.GetBase().Address == addr.IP.String() && c.GetBase().Port == addr.Port {
+			return c
+		}
+	}
+	return nil
+}
+
+func getUDPAddrCandidate(candidates []Candidate, addr *net.UDPAddr) Candidate {
+	for _, c := range candidates {
+		if c.GetBase().Address == addr.IP.String() && c.GetBase().Port == addr.Port {
+			return c
+		}
+	}
+	return nil
+}
+
+// HandleInbound processes traffic from a remote candidate
+func (a *Agent) HandleInbound(buf []byte, local *stun.TransportAddr, remote *net.UDPAddr) {
+	a.Lock()
+	defer a.Unlock()
+
+	localCandidate := getTransportAddrCandidate(a.localCandidates, local)
+	if localCandidate == nil {
+		// TODO debug
+		// fmt.Printf("Could not find local candidate for %s:%d ", local.IP.String(), local.Port)
+		return
+	}
+
+	remoteCandidate := getUDPAddrCandidate(a.remoteCandidates, remote)
+	if remoteCandidate == nil {
+		// TODO debug
+		// fmt.Printf("Could not find remote candidate for %s:%d ", remote.IP.String(), remote.Port)
+		return
+	}
+	remoteCandidate.GetBase().LastSeen = time.Now()
+
+	m, err := stun.NewMessage(buf)
+	if err != nil {
+		fmt.Printf("Failed to handle decode ICE from: %s to: %s error: %s", local.String(), remote.String(), err.Error())
+	} else if m.Class != stun.ClassRequest {
+		fmt.Printf("Wrong STUN Class ICE from: %s to: %s class: %s", local.String(), remote.String(), m.Class.String())
+	} else if m.Method != stun.MethodBinding {
+		fmt.Printf("Wrong STUN Method ICE from: %s to: %s method: %s", local.String(), remote.String(), m.Method.String())
+	}
+
+	if _, useCandidateFound := m.GetOneAttribute(stun.AttrUseCandidate); useCandidateFound {
+		a.selectedPair.remote = remoteCandidate
+		a.selectedPair.local = localCandidate
+	} else if a.isControlling && a.selectedPair.remote == nil && a.selectedPair.local == nil {
+		fmt.Println("Response to our ping (and we always send useCandidate)!")
+		// make this our new peer!
+	}
+
+	_, isControlled := m.GetOneAttribute(stun.AttrIceControlled)
+	if isControlled && a.isControlling == false {
+		panic("isControlled && a.isControlling == false")
+	}
+
+	_, isControlling := m.GetOneAttribute(stun.AttrIceControlling)
+	if isControlling && a.isControlling == true {
+		panic("isControlling && a.isControlling == true")
+	}
+
+	if out, err := stun.Build(stun.ClassSuccessResponse, stun.MethodBinding, m.TransactionID,
+		&stun.XorMappedAddress{
+			XorAddress: stun.XorAddress{
+				IP:   remote.IP,
+				Port: remote.Port,
+			},
+		},
+		&stun.MessageIntegrity{
+			Key: []byte(a.LocalPwd),
+		},
+		&stun.Fingerprint{},
+	); err != nil {
+		fmt.Printf("Failed to handle inbound ICE from: %s to: %s error: %s", local.String(), remote.String(), err.Error())
+	} else {
+		a.outboundCallback(out.Pack(), local, remote)
+	}
+}
+
+// SelectedPair gets the current selected pair's Addresses (or returns nil)
+func (a *Agent) SelectedPair() (local *stun.TransportAddr, remote *net.UDPAddr) {
+	a.RLock()
+	defer a.RUnlock()
+
+	if a.selectedPair.remote == nil || a.selectedPair.local == nil {
+		return nil, nil
+	}
+
+	return &stun.TransportAddr{
+			IP:   net.ParseIP(a.selectedPair.local.GetBase().Address),
+			Port: a.selectedPair.local.GetBase().Port,
+		}, &net.UDPAddr{
+			IP:   net.ParseIP(a.selectedPair.remote.GetBase().Address),
+			Port: a.selectedPair.remote.GetBase().Port,
+		}
 }

--- a/pkg/ice/candidate.go
+++ b/pkg/ice/candidate.go
@@ -1,0 +1,78 @@
+package ice
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+const (
+	hostCandidatePreference  uint16 = 126
+	srflxCandidatePreference uint16 = 100
+)
+
+// Candidate represents an ICE candidate
+type Candidate interface {
+	GetBase() *CandidateBase
+	String(component int) string
+}
+
+// CandidateBase represents an ICE candidate, a base with enough attributes
+// for host candidates, see CandidateSrflx and CandidateRelay for more
+type CandidateBase struct {
+	Protocol TransportType
+	Address  string
+	Port     int
+	LastSeen time.Time
+}
+
+func (c *CandidateBase) priority(typePreference uint16, component uint16) uint16 {
+	localPreference := uint16(rand.Uint32() / 2)
+	return (2^24)*typePreference +
+		(2^8)*localPreference +
+		(2^0)*(256-component)
+}
+
+// CandidateHost is a Candidate of typ Host
+type CandidateHost struct {
+	CandidateBase
+}
+
+// String for CandidateHost
+func (c *CandidateHost) String(component int) string {
+	return fmt.Sprintf("udpcandidate %d udp %d %s %d typ host generation 0",
+		component, c.CandidateBase.priority(hostCandidatePreference, uint16(component)), c.CandidateBase.Address, c.CandidateBase.Port)
+}
+
+// GetBase returns the CandidateBase, attributes shared between all Candidates
+func (c *CandidateHost) GetBase() *CandidateBase {
+	return &c.CandidateBase
+}
+
+// Address for CandidateHost
+func (c *CandidateHost) Address() string {
+	return c.CandidateBase.Address
+}
+
+// Port for CandidateHost
+func (c *CandidateHost) Port() int {
+	return c.CandidateBase.Port
+}
+
+// CandidateSrflx is a Candidate of typ Server-Reflexive
+type CandidateSrflx struct {
+	CandidateBase
+	RemoteAddress string
+	RemotePort    int
+}
+
+// String for CandidateSrflx
+func (c *CandidateSrflx) String(component int) string {
+	return fmt.Sprintf("udpcandidate %d udp %d %s %d typ srflx raddr %s rport %d generation 0",
+		component, c.CandidateBase.priority(srflxCandidatePreference, uint16(component)), c.CandidateBase.Address, c.CandidateBase.Port, c.RemoteAddress, c.RemotePort)
+}
+
+// GetBase returns the CandidateBase, attributes shared between all Candidates
+func (c *CandidateSrflx) GetBase() *CandidateBase {
+	return &c.CandidateBase
+}

--- a/pkg/ice/ice.go
+++ b/pkg/ice/ice.go
@@ -7,25 +7,43 @@ type ConnectionState int
 
 // List of supported States
 const (
-	// ConnectionStateNew ICE agent is gathering addresses
+	// ConnectionStateNew indicates that ICE agent is gathering addresses and that
+	// any of the ICE transports are in the "new" state and none of them are in
+	// the "checking", "disconnected" or "failed" state, or all ICE transports
+	// are in the "closed" state, or there are no transports.
 	ConnectionStateNew = iota + 1
 
-	// ConnectionStateChecking ICE agent has been given local and remote candidates, and is attempting to find a match
+	// ConnectionStateChecking indicates that ICE agent has been given local and
+	// remote candidates, and is attempting to find a match. Also
+	// ConnectionStateChecking indicates that ant of the ICE transports are
+	// in the "checking" state and none of them are in the "disconnected" or
+	// "failed" state.
 	ConnectionStateChecking
 
-	// ConnectionStateConnected ICE agent has a pairing, but is still checking other pairs
+	// ConnectionStateConnected indicates that ICE agent has a pairing, but is
+	// still checking other pairs. Also ConnectionStateConnected indicates that
+	// all ICE transports are in the "connected", "completed" or "closed"
+	// state and at least one of them is in the "connected" state.
 	ConnectionStateConnected
 
-	// ConnectionStateCompleted ICE agent has finished
+	// ConnectionStateCompleted indicates that ICE agent has finished and that
+	// all ICE transports are in the "completed" or "closed" state and at least
+	// one of them is in the "completed" state.
 	ConnectionStateCompleted
 
-	// ConnectionStateFailed ICE agent never could successfully connect
-	ConnectionStateFailed
-
-	// ConnectionStateDisconnected ICE agent connected successfully, but has entered a failed state
+	// ConnectionStateDisconnected indicates that ICE agent connected
+	// successfully, but has entered a failed state and that any of the ICE
+	// transports are in the "disconnected" state and none of them are in the
+	// "failed" state.
 	ConnectionStateDisconnected
 
-	// ConnectionStateClosed ICE agent has finished and is no longer handling requests
+	// ConnectionStateFailed indicates that ICE agent never could successfully
+	// connect and that any of the ICE transports are in the "failed" state.
+	ConnectionStateFailed
+
+	// ConnectionStateClosed indicates that ICE agent has finished and is no
+	// longer handling requests and that The RTCPeerConnection struct's IsClosed
+	// member variable is true.
 	ConnectionStateClosed
 )
 
@@ -39,10 +57,10 @@ func (c ConnectionState) String() string {
 		return "Connected"
 	case ConnectionStateCompleted:
 		return "Completed"
-	case ConnectionStateFailed:
-		return "Failed"
 	case ConnectionStateDisconnected:
 		return "Disconnected"
+	case ConnectionStateFailed:
+		return "Failed"
 	case ConnectionStateClosed:
 		return "Closed"
 	default:
@@ -54,13 +72,19 @@ func (c ConnectionState) String() string {
 type GatheringState int
 
 const (
-	// GatheringStateNew indicates candidate gatering is not yet started
+	// GatheringStateNew indicates candidate gatering is not yet started and
+	// that any of the ICE transports are in the "new" gathering state and
+	// none of the transports are in the "gathering" state, or there are no
+	// transports.
 	GatheringStateNew GatheringState = iota + 1
 
-	// GatheringStateGathering indicates candidate gatering is ongoing
+	// GatheringStateGathering indicates candidate gatering is ongoing and that
+	// any of the ICE transports are in the "gathering" state.
 	GatheringStateGathering
 
 	// GatheringStateComplete indicates candidate gatering has been completed
+	// and that at least one ICE transport exists, and all ICE transports are
+	// in the "completed" gathering state.
 	GatheringStateComplete
 )
 

--- a/pkg/ice/ice.go
+++ b/pkg/ice/ice.go
@@ -1,7 +1,5 @@
 package ice
 
-import "net"
-
 // ConnectionState is an enum showing the state of a ICE Connection
 type ConnectionState int
 
@@ -99,43 +97,4 @@ func (t GatheringState) String() string {
 	default:
 		return "Unknown"
 	}
-}
-
-// HostInterfaces generates a slice of all the IPs associated with interfaces
-func HostInterfaces() (ips []string) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return ips
-	}
-
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 {
-			continue // interface down
-		}
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue // loopback interface
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return ips
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip == nil || ip.IsLoopback() {
-				continue
-			}
-			ip = ip.To4()
-			if ip == nil {
-				continue // not an ipv4 address
-			}
-			ips = append(ips, ip.String())
-		}
-	}
-	return ips
 }

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -260,23 +260,13 @@ func (r *RTCPeerConnection) validateICECandidatePoolSize(config RTCConfiguration
 }
 
 func (r *RTCPeerConnection) setICEServers(config RTCConfiguration) error {
-	if len(config.ICEServers) > 0 {
-		var servers [][]ice.URL
-		for _, server := range config.ICEServers {
-			var urls []ice.URL
-			for _, rawURL := range server.URLs {
-				url, err := parseICEServer(server, rawURL)
-				if err != nil {
-					return err
-				}
-				urls = append(urls, url)
+	for _, server := range config.ICEServers {
+		for _, rawURL := range server.URLs {
+			url, err := parseICEServer(server, rawURL)
+			if err != nil {
+				return err
 			}
-			if len(urls) > 0 {
-				servers = append(servers, urls)
-			}
-		}
-		if len(servers) > 0 {
-			r.iceAgent.SetServers(servers)
+			r.networkManager.AddURL(&url)
 		}
 	}
 	return nil

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -62,7 +62,8 @@ type RTCOAuthCredential struct {
 type RTCICETransportPolicy int
 
 const (
-	// RTCICETransportPolicyRelay indicates only media relay candidates such as candidates passing through a TURN server are used
+	// RTCICETransportPolicyRelay indicates only media relay candidates such
+	// as candidates passing through a TURN server are used
 	RTCICETransportPolicyRelay RTCICETransportPolicy = iota + 1
 
 	// RTCICETransportPolicyAll indicates any type of candidate is used
@@ -130,17 +131,39 @@ func (t RTCRtcpMuxPolicy) String() string {
 	}
 }
 
-// RTCConfiguration contains RTCPeerConfiguration options
+// RTCConfiguration contains RTCPeerConfiguration options to configure the new connection
 type RTCConfiguration struct {
-	// ICEServers holds multiple RTCICEServer instances, each describing one server which may be used by the ICE agent;
-	// these are typically STUN and/or TURN servers. If this isn't specified, the ICE agent may choose to use its own ICE servers;
-	// otherwise, the connection attempt will be made with no STUN or TURN server available, which limits the connection to local peers.
-	ICEServers           []RTCICEServer
-	ICETransportPolicy   RTCICETransportPolicy
-	BundlePolicy         RTCBundlePolicy
-	RtcpMuxPolicy        RTCRtcpMuxPolicy
-	PeerIdentity         string
-	Certificates         []RTCCertificate
+
+	// ICEServers holds multiple RTCICEServer instances, each describing one
+	// server which may be used by the ICE agent; these are typically STUN
+	// and/or TURN servers. If this isn't specified, the ICE agent may choose
+	// to use its own ICE servers; otherwise, the connection attempt will be
+	// made with no STUN or TURN server available, which limits the connection
+	// to local peers.
+	ICEServers []RTCICEServer
+
+	// ICETransportPolicy indicates which candidates the ICE Agent is allowed
+	// to use. Defaults to "all".
+	ICETransportPolicy RTCICETransportPolicy
+
+	// BundlePolicy indicates which media-bundling policy to use when gathering
+	// ICE candidates. Defaults to "balanced".
+	BundlePolicy RTCBundlePolicy
+
+	// RtcpMuxPolicy indicates which rtcp-mux policy to use when gathering ICE
+	// candidates. Defaults to "require".
+	RtcpMuxPolicy RTCRtcpMuxPolicy
+
+	// PeerIdentity sets the target peer identity for the RTCPeerConnection.
+	// The RTCPeerConnection will not establish a connection to a remote peer
+	// unless it can be successfully authenticated with the provided name.
+	PeerIdentity string
+
+	// Certificates contains a set of certificates that the RTCPeerConnection
+	// uses to authenticate.
+	Certificates []RTCCertificate
+
+	// ICECandidatePoolSize sets the size of the prefetched ICE pool.
 	ICECandidatePoolSize uint8
 }
 

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -81,12 +81,6 @@ type RTCPeerConnection struct {
 
 	config RTCConfiguration
 
-	// ICE: TODO: Move to ICEAgent
-	iceAgent           *ice.Agent
-	iceState           ice.ConnectionState
-	iceGatheringState  ice.GatheringState
-	iceConnectionState ice.ConnectionState
-
 	networkManager *network.Manager
 
 	// Signaling
@@ -124,22 +118,18 @@ type RTCPeerConnection struct {
 // New creates a new RTCPeerConfiguration with the provided configuration
 func New(config RTCConfiguration) (*RTCPeerConnection, error) {
 	r := &RTCPeerConnection{
-		config:             config,
-		signalingState:     RTCSignalingStateStable,
-		iceAgent:           ice.NewAgent(),
-		iceGatheringState:  ice.GatheringStateNew,
-		iceConnectionState: ice.ConnectionStateNew,
-		connectionState:    RTCPeerConnectionStateNew,
-		mediaEngine:        DefaultMediaEngine,
-		dataChannels:       make(map[uint16]*RTCDataChannel),
+		config:          config,
+		signalingState:  RTCSignalingStateStable,
+		connectionState: RTCPeerConnectionStateNew,
+		mediaEngine:     DefaultMediaEngine,
+		dataChannels:    make(map[uint16]*RTCDataChannel),
 	}
-	err := r.SetConfiguration(config)
+	var err error
+	r.networkManager, err = network.NewManager(r.generateChannel, r.dataChannelEventHandler, r.iceStateChange)
 	if err != nil {
 		return nil, err
 	}
-
-	r.networkManager, err = network.NewManager([]byte(r.iceAgent.Pwd), r.generateChannel, r.dataChannelEventHandler, r.iceStateChange)
-	if err != nil {
+	if err := r.SetConfiguration(config); err != nil {
 		return nil, err
 	}
 
@@ -202,10 +192,10 @@ func (r *RTCPeerConnection) iceStateChange(newState ice.ConnectionState) {
 	r.Lock()
 	defer r.Unlock()
 
-	if r.OnICEConnectionStateChange != nil && r.iceState != newState {
-		r.OnICEConnectionStateChange(newState)
-	}
-	r.iceState = newState
+	// if r.OnICEConnectionStateChange != nil && r.iceState != newState {
+	// 	r.OnICEConnectionStateChange(newState)
+	// }
+	// r.iceState = newState
 }
 
 func (r *RTCPeerConnection) dataChannelEventHandler(e network.DataChannelEvent) {

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -21,22 +21,32 @@ type RTCPeerConnectionState int
 
 const (
 
-	// RTCPeerConnectionStateNew indicates some of the ICE or DTLS transports are in status new
+	// RTCPeerConnectionStateNew indicates some of the ICE or DTLS transports
+	// are in status new and none of the transports are in the "connecting",
+	// "checking", "failed" or "disconnected" state, or all transports are in
+	// the "closed" state, or there are no transports.
 	RTCPeerConnectionStateNew RTCPeerConnectionState = iota + 1
 
-	// RTCPeerConnectionStateConnecting indicates some of the ICE or DTLS transports are in status connecting or checking
+	// RTCPeerConnectionStateConnecting indicates some of the ICE or DTLS
+	// transports are in status connecting or checking and none of them is in
+	// the "failed" state.
 	RTCPeerConnectionStateConnecting
 
-	// RTCPeerConnectionStateConnected indicates all of the ICE or DTLS transports are in status connected or completed
+	// RTCPeerConnectionStateConnected indicates all of the ICE or DTLS
+	// transports are in status "connected", "completed" or "closed" state
+	// and at least one of them is in the "connected" or "completed" state.
 	RTCPeerConnectionStateConnected
 
-	// RTCPeerConnectionStateDisconnected indicates some of the ICE or DTLS transports are in status disconnected
+	// RTCPeerConnectionStateDisconnected indicates some of the ICE or DTLS
+	// transports are in status disconnected and none of them are in the
+	// "failed" or "connecting" or "checking" state.
 	RTCPeerConnectionStateDisconnected
 
-	// RTCPeerConnectionStateFailed indicates some of the ICE or DTLS transports are in status failed
+	// RTCPeerConnectionStateFailed indicates some of the ICE or DTLS transports
+	// are in status failed.
 	RTCPeerConnectionStateFailed
 
-	// RTCPeerConnectionStateClosed indicates the peer connection is closed
+	// RTCPeerConnectionStateClosed indicates the peer connection is closed.
 	RTCPeerConnectionStateClosed
 )
 
@@ -59,12 +69,15 @@ func (t RTCPeerConnectionState) String() string {
 	}
 }
 
-// RTCPeerConnection represents a WebRTC connection between itself and a remote peer
+// RTCPeerConnection represents a WebRTC connection between itself and a remote
+// peer. It provides an interface for managing and monitoring a remote peer
+// connection lifecycle.
 type RTCPeerConnection struct {
 	sync.RWMutex
 
-	// ICE
-	OnICEConnectionStateChange func(iceConnectionState ice.ConnectionState)
+	// OnICEConnectionStateChange event handler defines a callback method to be
+	// called when the state of the icegatheringstatechange event has beeb fired.
+	OnICEConnectionStateChange func(ice.ConnectionState)
 
 	config RTCConfiguration
 

--- a/signaling.go
+++ b/signaling.go
@@ -58,19 +58,27 @@ type RTCSignalingState int
 
 const (
 
-	// RTCSignalingStateStable indicates there is no offer­answer exchange in progress.
+	// RTCSignalingStateStable indicates there is no offer­answer exchange in
+	// progress. This is the initial state and both local and remote
+	// descriptions are empty.
 	RTCSignalingStateStable RTCSignalingState = iota + 1
 
-	// RTCSignalingStateHaveLocalOffer indicates A local description, of type "offer", has been successfully applied.
+	// RTCSignalingStateHaveLocalOffer indicates a local description, of type
+	// "offer", has been successfully applied.
 	RTCSignalingStateHaveLocalOffer
 
-	// RTCSignalingStateHaveRemoteOffer indicates A remote description, of type "offer", has been successfully applied.
+	// RTCSignalingStateHaveRemoteOffer indicates a remote description, of type
+	// "offer", has been successfully applied.
 	RTCSignalingStateHaveRemoteOffer
 
-	// RTCSignalingStateHaveLocalPranswer indicates A remote description of type "offer" has been successfully applied and a local description of type "pranswer" has been successfully applied.
+	// RTCSignalingStateHaveLocalPranswer indicates a remote description of
+	// type "offer" has been successfully applied and a local description of
+	// type "pranswer" has been successfully applied.
 	RTCSignalingStateHaveLocalPranswer
 
-	// RTCSignalingStateHaveRemotePranswer indicates A local description of type "offer" has been successfully applied and a remote description of type "pranswer" has been successfully applied.
+	// RTCSignalingStateHaveRemotePranswer indicates A local description of
+	// type "offer" has been successfully applied and a remote description of
+	// type "pranswer" has been successfully applied.
 	RTCSignalingStateHaveRemotePranswer
 
 	// RTCSignalingStateClosed indicates The RTCPeerConnection has been closed.

--- a/signaling.go
+++ b/signaling.go
@@ -2,56 +2,22 @@ package webrtc
 
 import (
 	"fmt"
-	"math/rand"
-	"net"
 	"strings"
-	"time"
 
-	"github.com/pions/pkg/stun"
 	"github.com/pions/webrtc/internal/sdp"
-	"github.com/pions/webrtc/pkg/ice"
 	"github.com/pkg/errors"
 )
 
-/*
-                      setRemote(OFFER)               setLocal(PRANSWER)
-                          /-----\                               /-----\
-                          |     |                               |     |
-                          v     |                               v     |
-           +---------------+    |                +---------------+    |
-           |               |----/                |               |----/
-           |  have-        | setLocal(PRANSWER)  | have-         |
-           |  remote-offer |------------------- >| local-pranswer|
-           |               |                     |               |
-           |               |                     |               |
-           +---------------+                     +---------------+
-                ^   |                                   |
-                |   | setLocal(ANSWER)                  |
-  setRemote(OFFER)  |                                   |
-                |   V                  setLocal(ANSWER) |
-           +---------------+                            |
-           |               |                            |
-           |               |<---------------------------+
-           |    stable     |
-           |               |<---------------------------+
-           |               |                            |
-           +---------------+          setRemote(ANSWER) |
-                ^   |                                   |
-                |   | setLocal(OFFER)                   |
-  setRemote(ANSWER) |                                   |
-                |   V                                   |
-           +---------------+                     +---------------+
-           |               |                     |               |
-           |  have-        | setRemote(PRANSWER) |have-          |
-           |  local-offer  |------------------- >|remote-pranswer|
-           |               |                     |               |
-           |               |----\                |               |----\
-           +---------------+    |                +---------------+    |
-                          ^     |                               ^     |
-                          |     |                               |     |
-                          \-----/                               \-----/
-                      setLocal(OFFER)               setRemote(PRANSWER)
-*/
+// RTCAnswerOptions describes the options used to control the answer creation process
+type RTCAnswerOptions struct {
+	VoiceActivityDetection bool
+}
+
+// RTCOfferOptions describes the options used to control the offer creation process
+type RTCOfferOptions struct {
+	VoiceActivityDetection bool
+	ICERestart             bool
+}
 
 // RTCSignalingState indicates the state of the offer/answer process
 type RTCSignalingState int
@@ -149,224 +115,141 @@ func (r *RTCPeerConnection) SetRemoteDescription(desc RTCSessionDescription) err
 		return errors.Errorf("remoteDescription is already defined, SetRemoteDescription can only be called once")
 	}
 
+	isControllingICE := true
+	if desc.Type == RTCSdpTypeOffer {
+		isControllingICE = false
+	}
+
 	r.currentRemoteDescription = &desc
-
 	r.remoteDescription = &sdp.SessionDescription{}
+	if err := r.remoteDescription.Unmarshal(desc.Sdp); err != nil {
+		return err
+	}
 
-	return r.remoteDescription.Unmarshal(desc.Sdp)
-}
+	for _, m := range r.remoteDescription.MediaDescriptions {
+		for _, a := range m.Attributes {
+			if strings.HasPrefix(a, "candidate") {
+				if c := sdp.ICECandidateBuild(a); c != nil {
+					r.networkManager.IceAgent.AddRemoteCandidate(c)
+				} else {
+					fmt.Printf("Tried to parse ICE candidate, but failed %s ", a)
+				}
 
-// RTCOfferOptions describes the options used to control the offer creation process
-type RTCOfferOptions struct {
-	VoiceActivityDetection bool
-	ICERestart             bool
-}
+			}
+		}
+	}
+	r.networkManager.IceAgent.Start(isControllingICE)
 
-// TODO
-type candidate struct {
-	transport    string
-	basePriority uint16
-	ip           string
-	port         int
-	typ          string
+	return nil
 }
 
 // CreateOffer starts the RTCPeerConnection and generates the localDescription
 func (r *RTCPeerConnection) CreateOffer(options *RTCOfferOptions) (RTCSessionDescription, error) {
-	panic("TODO")
-	// if options != nil {
-	// 	panic("TODO handle options")
-	// }
-	// if r.IsClosed {
-	// 	return RTCSessionDescription{}, &InvalidStateError{Err: ErrConnectionClosed}
-	// }
-	// useIdentity := r.idpLoginURL != nil
-	// if useIdentity {
-	// 	panic("TODO handle identity provider")
-	// }
+	useIdentity := r.idpLoginURL != nil
+	if options != nil {
+		panic("TODO handle options")
+	} else if useIdentity {
+		panic("TODO handle identity provider")
+	} else if r.IsClosed {
+		return RTCSessionDescription{}, &InvalidStateError{Err: ErrConnectionClosed}
+	}
 
-	// d := sdp.NewJSEPSessionDescription(
-	// 	r.tlscfg.Fingerprint(),
-	// 	useIdentity).
-	// 	WithValueAttribute(sdp.AttrKeyGroup, "BUNDLE audio video") // TODO: Support BUNDLE
+	candidates := r.networkManager.IceAgent.LocalCandidates()
+	d := sdp.NewJSEPSessionDescription(r.networkManager.DTLSFingerprint(), useIdentity)
 
-	// var streamlabels string
-	// for _, transceiver := range r.rtpTransceivers {
-	// 	if transceiver.Sender == nil ||
-	// 		transceiver.Sender.Track == nil {
-	// 		continue
-	// 	}
-	// 	track := transceiver.Sender.Track
-	// 	cname := "pion"      // TODO: Support RTP streams synchronization
-	// 	steamlabel := "pion" // TODO: Support steam labels
-	// 	codec, err := r.mediaEngine.getCodec(track.PayloadType)
-	// 	if err != nil {
-	// 		return RTCSessionDescription{}, err
-	// 	}
-	// 	media := sdp.NewJSEPMediaDescription(track.Kind.String(), []string{}).
-	// 		WithValueAttribute(sdp.AttrKeyConnectionSetup, sdp.ConnectionRoleActive.String()). // TODO: Support other connection types
-	// 		WithValueAttribute(sdp.AttrKeyMID, transceiver.Mid).
-	// 		WithPropertyAttribute(transceiver.Direction.String()).
-	// 		WithICECredentials(r.iceAgent.Ufrag, r.iceAgent.Pwd).
-	// 		WithPropertyAttribute(sdp.AttrKeyICELite).   // TODO: get ICE type from ICE Agent
-	// 		WithPropertyAttribute(sdp.AttrKeyRtcpMux).   // TODO: support RTCP fallback
-	// 		WithPropertyAttribute(sdp.AttrKeyRtcpRsize). // TODO: Support Reduced-Size RTCP?
-	// 		WithCodec(
-	// 			codec.PayloadType,
-	// 			codec.Name,
-	// 			codec.ClockRate,
-	// 			codec.Channels,
-	// 			codec.SdpFmtpLine,
-	// 		).
-	// 		WithMediaSource(track.Ssrc, cname, steamlabel, track.Label)
-	// 	err = r.addICECandidates(media)
-	// 	if err != nil {
-	// 		return RTCSessionDescription{}, err
-	// 	}
-	// 	streamlabels = streamlabels + " " + steamlabel
+	r.addRTPMediaSections(d, []RTCRtpCodecType{RTCRtpCodecTypeAudio, RTCRtpCodecTypeVideo}, candidates)
+	r.addDataMediaSection(d, candidates)
+	d = d.WithValueAttribute(sdp.AttrKeyGroup, "audio video data")
 
-	// 	d.WithMedia(media)
-	// }
-
-	// d.WithValueAttribute(sdp.AttrKeyMsidSemantic, " "+sdp.SemanticTokenWebRTCMediaStreams+streamlabels)
-
-	// return RTCSessionDescription{
-	// 	Type: RTCSdpTypeOffer,
-	// 	Sdp:  d.Marshal(),
-	// }, nil
-}
-
-// RTCAnswerOptions describes the options used to control the answer creation process
-type RTCAnswerOptions struct {
-	VoiceActivityDetection bool
+	return RTCSessionDescription{
+		Type: RTCSdpTypeOffer,
+		Sdp:  d.Marshal(),
+	}, nil
 }
 
 // CreateAnswer starts the RTCPeerConnection and generates the localDescription
-func (r *RTCPeerConnection) CreateAnswer(options *RTCOfferOptions) (RTCSessionDescription, error) {
+func (r *RTCPeerConnection) CreateAnswer(options *RTCAnswerOptions) (RTCSessionDescription, error) {
+	useIdentity := r.idpLoginURL != nil
 	if options != nil {
 		panic("TODO handle options")
-	}
-	if r.IsClosed {
-		return RTCSessionDescription{}, &InvalidStateError{Err: ErrConnectionClosed}
-	}
-	useIdentity := r.idpLoginURL != nil
-	if useIdentity {
+	} else if useIdentity {
 		panic("TODO handle identity provider")
-	}
-
-	candidates, err := r.buildCandidates()
-	if err != nil {
+	} else if r.IsClosed {
 		return RTCSessionDescription{}, &InvalidStateError{Err: ErrConnectionClosed}
 	}
-
-	d := sdp.NewJSEPSessionDescription(
-		r.networkManager.DTLSFingerprint(),
-		useIdentity)
 
 	bundleValue := "BUNDLE"
+	mediaSectionsToAdd := []RTCRtpCodecType{}
+	addData := false
 	for _, remoteMedia := range r.remoteDescription.MediaDescriptions {
 		if strings.HasPrefix(remoteMedia.MediaName, "audio") {
 			bundleValue += " audio"
-			_, err := r.addAnswerMedia(d, RTCRtpCodecTypeAudio, candidates)
-			if err != nil {
-				return RTCSessionDescription{}, err
-			}
+			mediaSectionsToAdd = append(mediaSectionsToAdd, RTCRtpCodecTypeAudio)
 		} else if strings.HasPrefix(remoteMedia.MediaName, "video") {
 			bundleValue += " video"
-			_, err := r.addAnswerMedia(d, RTCRtpCodecTypeVideo, candidates)
-			if err != nil {
-				return RTCSessionDescription{}, err
-			}
-
+			mediaSectionsToAdd = append(mediaSectionsToAdd, RTCRtpCodecTypeVideo)
 		} else if strings.HasPrefix(remoteMedia.MediaName, "application") {
 			bundleValue += " data"
-			r.addAnswerData(d, candidates)
+			addData = true
 		}
 	}
 
+	candidates := r.networkManager.IceAgent.LocalCandidates()
+	d := sdp.NewJSEPSessionDescription(r.networkManager.DTLSFingerprint(), useIdentity)
+
+	r.addRTPMediaSections(d, mediaSectionsToAdd, candidates)
+	if addData {
+		r.addDataMediaSection(d, candidates)
+	}
 	d = d.WithValueAttribute(sdp.AttrKeyGroup, bundleValue)
+
 	return RTCSessionDescription{
 		Type: RTCSdpTypeAnswer,
 		Sdp:  d.Marshal(),
 	}, nil
 }
 
-func (r *RTCPeerConnection) addAnswerMedia(d *sdp.SessionDescription, codecType RTCRtpCodecType, candidates []candidate) (string, error) {
-	added := false
-
-	var streamlabels string
-	for _, transceiver := range r.rtpTransceivers {
-		if transceiver.Sender == nil ||
-			transceiver.Sender.Track == nil ||
-			transceiver.Sender.Track.Kind != codecType {
-			continue
-		}
-		track := transceiver.Sender.Track
-		cname := track.Label      // TODO: Support RTP streams synchronization
-		steamlabel := track.Label // TODO: Support steam labels
-		codec, err := r.mediaEngine.getCodec(track.PayloadType)
-		if err != nil {
-			return "", err
-		}
-		media := sdp.NewJSEPMediaDescription(track.Kind.String(), []string{}).
-			WithValueAttribute(sdp.AttrKeyConnectionSetup, sdp.ConnectionRoleActive.String()). // TODO: Support other connection types
-			WithValueAttribute(sdp.AttrKeyMID, transceiver.Mid).
-			WithPropertyAttribute(RTCRtpTransceiverDirectionSendrecv.String()).
-			WithICECredentials(r.iceAgent.Ufrag, r.iceAgent.Pwd).
-			WithPropertyAttribute(sdp.AttrKeyICELite).   // TODO: get ICE type from ICE Agent
-			WithPropertyAttribute(sdp.AttrKeyRtcpMux).   // TODO: support RTCP fallback
-			WithPropertyAttribute(sdp.AttrKeyRtcpRsize). // TODO: Support Reduced-Size RTCP?
-			WithCodec(
-				codec.PayloadType,
-				codec.Name,
-				codec.ClockRate,
-				codec.Channels,
-				codec.SdpFmtpLine,
-			).
-			WithMediaSource(track.Ssrc, cname, steamlabel, track.Label)
-
-		for _, c := range candidates {
-			media.WithCandidate(1, c.transport, c.basePriority, c.ip, c.port, c.typ)
-		}
-		media.WithPropertyAttribute("end-of-candidates") // TODO: Support full trickle-ice
-		d.WithMedia(media)
-		streamlabels = streamlabels + " " + steamlabel
-		added = true
-	}
-
-	if !added {
-		// Add media line to advertise capabilities
+/*
+	TODO If we are generating an offer only include media sections we want
+*/
+func (r *RTCPeerConnection) addRTPMediaSections(d *sdp.SessionDescription, mediaTypes []RTCRtpCodecType, candidates []string) {
+	addMediaType := func(codecType RTCRtpCodecType) {
 		media := sdp.NewJSEPMediaDescription(codecType.String(), []string{}).
 			WithValueAttribute(sdp.AttrKeyConnectionSetup, sdp.ConnectionRoleActive.String()). // TODO: Support other connection types
 			WithValueAttribute(sdp.AttrKeyMID, codecType.String()).
 			WithPropertyAttribute(RTCRtpTransceiverDirectionSendrecv.String()).
-			WithICECredentials(r.iceAgent.Ufrag, r.iceAgent.Pwd). // TODO: get credendials form ICE agent
-			WithPropertyAttribute(sdp.AttrKeyICELite).            // TODO: get ICE type from ICE Agent (#23)
-			WithPropertyAttribute(sdp.AttrKeyRtcpMux).            // TODO: support RTCP fallback
-			WithPropertyAttribute(sdp.AttrKeyRtcpRsize)           // TODO: Support Reduced-Size RTCP?
+			WithICECredentials(r.networkManager.IceAgent.LocalUfrag, r.networkManager.IceAgent.LocalPwd).
+			WithPropertyAttribute(sdp.AttrKeyRtcpMux).  // TODO: support RTCP fallback
+			WithPropertyAttribute(sdp.AttrKeyRtcpRsize) // TODO: Support Reduced-Size RTCP?
 
 		for _, codec := range r.mediaEngine.getCodecsByKind(codecType) {
-			media.WithCodec(
-				codec.PayloadType,
-				codec.Name,
-				codec.ClockRate,
-				codec.Channels,
-				codec.SdpFmtpLine,
-			)
+			media.WithCodec(codec.PayloadType, codec.Name, codec.ClockRate, codec.Channels, codec.SdpFmtpLine)
+		}
+
+		for _, tranceiver := range r.rtpTransceivers {
+			if tranceiver.Sender == nil ||
+				tranceiver.Sender.Track == nil ||
+				tranceiver.Sender.Track.Kind != codecType {
+				continue
+			}
+			track := tranceiver.Sender.Track
+			media = media.WithMediaSource(track.Ssrc, track.Label /* cname */, track.Label /* streamLabel */, track.Label)
 		}
 
 		for _, c := range candidates {
-			media.WithCandidate(1, c.transport, c.basePriority, c.ip, c.port, c.typ)
+			media.WithCandidate(c)
 		}
-		media.WithPropertyAttribute("end-of-candidates") // TODO: Support full trickle-ice
+		media.WithPropertyAttribute("end-of-candidates")
 		d.WithMedia(media)
+
 	}
 
-	return streamlabels, nil
-
+	for _, c := range mediaTypes {
+		addMediaType(c)
+	}
 }
 
-func (r *RTCPeerConnection) addAnswerData(d *sdp.SessionDescription, candidates []candidate) {
+func (r *RTCPeerConnection) addDataMediaSection(d *sdp.SessionDescription, candidates []string) {
 	media := (&sdp.MediaDescription{
 		MediaName:      "application 9 DTLS/SCTP 5000",
 		ConnectionData: "IN IP4 0.0.0.0",
@@ -375,89 +258,12 @@ func (r *RTCPeerConnection) addAnswerData(d *sdp.SessionDescription, candidates 
 		WithValueAttribute(sdp.AttrKeyConnectionSetup, sdp.ConnectionRoleActive.String()). // TODO: Support other connection types
 		WithValueAttribute(sdp.AttrKeyMID, "data").
 		WithValueAttribute("sctpmap:5000", "webrtc-datachannel 1024").
-		WithICECredentials(r.iceAgent.Ufrag, r.iceAgent.Pwd).
-		WithPropertyAttribute(sdp.AttrKeyICELite) // TODO: get ICE type from ICE Agent
+		WithICECredentials(r.networkManager.IceAgent.LocalUfrag, r.networkManager.IceAgent.LocalPwd)
 
 	for _, c := range candidates {
-		media.WithCandidate(1, c.transport, c.basePriority, c.ip, c.port, c.typ)
+		media.WithCandidate(c)
 	}
-	media.WithPropertyAttribute("end-of-candidates") // TODO: Support full trickle-ice
+	media.WithPropertyAttribute("end-of-candidates")
 
 	d.WithMedia(media)
-}
-
-func (r *RTCPeerConnection) buildCandidates() ([]candidate, error) {
-	basePriority := uint16(rand.Uint32() & (1<<16 - 1))
-	candidates := make([]candidate, 0)
-
-	for _, c := range ice.HostInterfaces() {
-		boundAddress, err := r.networkManager.Listen(c + ":0")
-		if err != nil {
-			return nil, err
-		}
-
-		candidates = append(candidates, candidate{
-			transport:    "udp",
-			basePriority: basePriority,
-			ip:           boundAddress.IP.String(),
-			port:         boundAddress.Port,
-			typ:          "host",
-		})
-
-		basePriority = basePriority + 1
-	}
-
-	for _, servers := range r.iceAgent.Servers {
-		for _, server := range servers {
-			if server.Type != ice.ServerTypeSTUN {
-				continue
-			}
-			// TODO Do we want the timeout to be configurable?
-			proto := server.TransportType.String()
-			client, err := stun.NewClient(proto, fmt.Sprintf("%s:%d", server.Host, server.Port), time.Second*5)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to create STUN client")
-			}
-			localAddr, ok := client.LocalAddr().(*net.UDPAddr)
-			if !ok {
-				return nil, errors.Errorf("Failed to cast STUN client to UDPAddr")
-			}
-
-			resp, err := client.Request()
-			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to make STUN request")
-			}
-
-			if err = client.Close(); err != nil {
-				return nil, errors.Wrapf(err, "Failed to close STUN client")
-			}
-
-			attr, ok := resp.GetOneAttribute(stun.AttrXORMappedAddress)
-			if !ok {
-				return nil, errors.Errorf("Got respond from STUN server that did not contain XORAddress")
-			}
-
-			var addr stun.XorAddress
-			if err = addr.Unpack(resp, attr); err != nil {
-				return nil, errors.Wrapf(err, "Failed to unpack STUN XorAddress response")
-			}
-
-			boundAddress, err := r.networkManager.Listen(fmt.Sprintf("0.0.0.0:%d", localAddr.Port))
-			if err != nil {
-				return nil, err
-			}
-
-			candidates = append(candidates, candidate{
-				transport:    "udp",
-				basePriority: basePriority,
-				ip:           addr.IP.String(),
-				port:         boundAddress.Port,
-				typ:          "srflx",
-			})
-
-			basePriority = basePriority + 1
-		}
-	}
-
-	return candidates, nil
 }


### PR DESCRIPTION
Basically this pull request is not going to contain any programming changes to the library with the exception of changed in the orders of variables in different structures. For the most part everything is really synced up but as I am going through the RFC that are still things that are in-flux and are not organized. It just makes it really hard to follow when I constantly have to jump from one place to another between the RFC and the code.

The bottom line goal I am trying to achieve here is so that if someone is reading our documentations they are not necessarily need to go to the RFC in order to understand the more in depth stuff. I am going at it this way because I am also learning the whole library. Once I am up to speed I'll be able to add more documentations and tutorials for a wider range of audience and not just in-depth information.