### PR TITLE
SessionDescription: Allow json (un)marshalling.

### DIFF
--- a/rtcsdptype.go
+++ b/rtcsdptype.go
@@ -1,5 +1,10 @@
 package webrtc
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // RTCSdpType describes the type of an RTCSessionDescription.
 type RTCSdpType int
 
@@ -66,4 +71,31 @@ func (t RTCSdpType) String() string {
 	default:
 		return ErrUnknownType.Error()
 	}
+}
+
+// MarshalJSON enables JSON marshalling of a RTCSdpType
+func (t RTCSdpType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// UnmarshalJSON enables JSON unmarshalling of a RTCSdpType
+func (t RTCSdpType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch strings.ToLower(s) {
+	default:
+		return ErrUnknownType
+	case "offer":
+		t = RTCSdpTypeOffer
+	case "pranswer":
+		t = RTCSdpTypePranswer
+	case "answer":
+		t = RTCSdpTypeAnswer
+	case "rollback":
+		t = RTCSdpTypeRollback
+	}
+
+	return nil
 }

--- a/rtcsdptype.go
+++ b/rtcsdptype.go
@@ -73,13 +73,13 @@ func (t RTCSdpType) String() string {
 	}
 }
 
-// MarshalJSON enables JSON marshalling of a RTCSdpType
+// MarshalJSON enables JSON marshaling of a RTCSdpType
 func (t RTCSdpType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
 
-// UnmarshalJSON enables JSON unmarshalling of a RTCSdpType
-func (t RTCSdpType) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON enables JSON unmarshaling of a RTCSdpType
+func (t *RTCSdpType) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
@@ -88,13 +88,13 @@ func (t RTCSdpType) UnmarshalJSON(b []byte) error {
 	default:
 		return ErrUnknownType
 	case "offer":
-		t = RTCSdpTypeOffer
+		*t = RTCSdpTypeOffer
 	case "pranswer":
-		t = RTCSdpTypePranswer
+		*t = RTCSdpTypePranswer
 	case "answer":
-		t = RTCSdpTypeAnswer
+		*t = RTCSdpTypeAnswer
 	case "rollback":
-		t = RTCSdpTypeRollback
+		*t = RTCSdpTypeRollback
 	}
 
 	return nil

--- a/rtcsessiondescription.go
+++ b/rtcsessiondescription.go
@@ -6,8 +6,8 @@ import (
 
 // RTCSessionDescription is used to expose local and remote session descriptions.
 type RTCSessionDescription struct {
-	Type RTCSdpType
-	Sdp  string
+	Type RTCSdpType `json:"type"`
+	Sdp  string     `json:"sdp"`
 
 	// This will never be initialized by callers, internal use only
 	parsed *sdp.SessionDescription

--- a/rtcsessiondescription_test.go
+++ b/rtcsessiondescription_test.go
@@ -1,0 +1,59 @@
+package webrtc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRTCSessionDescription_JSON(t *testing.T) {
+	testCases := []struct {
+		desc           RTCSessionDescription
+		expectedString string
+		unmarshalErr   error
+	}{
+		{RTCSessionDescription{Type: RTCSdpTypeOffer, Sdp: "sdp"}, `{"type":"offer","sdp":"sdp"}`, nil},
+		{RTCSessionDescription{Type: RTCSdpTypePranswer, Sdp: "sdp"}, `{"type":"pranswer","sdp":"sdp"}`, nil},
+		{RTCSessionDescription{Type: RTCSdpTypeAnswer, Sdp: "sdp"}, `{"type":"answer","sdp":"sdp"}`, nil},
+		{RTCSessionDescription{Type: RTCSdpTypeRollback, Sdp: "sdp"}, `{"type":"rollback","sdp":"sdp"}`, nil},
+		{RTCSessionDescription{Type: RTCSdpType(Unknown), Sdp: "sdp"}, `{"type":"unknown","sdp":"sdp"}`, ErrUnknownType},
+	}
+
+	for i, testCase := range testCases {
+		descData, err := json.Marshal(testCase.desc)
+		assert.Nil(t,
+			err,
+			"testCase: %d %v marshal err: %v", i, testCase, err,
+		)
+
+		assert.Equal(t,
+			string(descData),
+			testCase.expectedString,
+			"testCase: %d %v", i, testCase,
+		)
+
+		var desc RTCSessionDescription
+		err = json.Unmarshal(descData, &desc)
+
+		if testCase.unmarshalErr != nil {
+			assert.Equal(t,
+				err,
+				testCase.unmarshalErr,
+				"testCase: %d %v", i, testCase,
+			)
+			continue
+		}
+
+		assert.Nil(t,
+			err,
+			"testCase: %d %v unmarshal err: %v", i, testCase, err,
+		)
+
+		assert.Equal(t,
+			desc,
+			testCase.desc,
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}


### PR DESCRIPTION
Allow json (un)marshalling of a SessionDescription for easier exchange, especially with JavaScript clients.

cc #39