### PR TITLE
nodejs bundle

### DIFF
--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -525,6 +525,7 @@ func (pc *RTCPeerConnection) CreateAnswer(options *RTCAnswerOptions) (RTCSession
 			}
 		} else if strings.HasPrefix(*remoteMedia.MediaName.String(), "application") {
 			pc.addDataMediaSection(d, midValue, candidates, sdp.ConnectionRoleActive)
+			appendBundle()
 		}
 	}
 


### PR DESCRIPTION
Nodejs fails to apply an sdp answer if it has a bundle attribute without any mids.