### PR TITLE
Allow panics in test files

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -9,7 +9,7 @@ DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"
 do
-	if grep -R $EXCLUDE_DIRECTORIES -e "$disallowedFunction" "$SCRIPT_PATH/.." | grep -v nolint; then
+	if grep -R $EXCLUDE_DIRECTORIES -e "$disallowedFunction" "$SCRIPT_PATH/.." | grep -v -e '_test.go' -e 'nolint'; then
 		echo "$disallowedFunction may only be used in example code"
 		exit 1
 	fi


### PR DESCRIPTION
The lint-disallowed-functions-in-library.sh lint is
stopping people from  using helpful functions in tests, raise
the restriction in files that match _test.go

Resolves #127