### PR TITLE
Enum structs implemented from Spec needed for onion design.

### DIFF
--- a/rtcbundlepolicy.go
+++ b/rtcbundlepolicy.go
@@ -31,9 +31,7 @@ const (
 	rtcBundlePolicyMaxBundleStr = "max-bundle"
 )
 
-// NewRTCBundlePolicy defines a procedure for creating a new RTCBundlePolicy
-// from a raw string naming the bundle policy.
-func NewRTCBundlePolicy(raw string) RTCBundlePolicy {
+func newRTCBundlePolicy(raw string) RTCBundlePolicy {
 	switch raw {
 	case rtcBundlePolicyBalancedStr:
 		return RTCBundlePolicyBalanced

--- a/rtcbundlepolicy_test.go
+++ b/rtcbundlepolicy_test.go
@@ -19,8 +19,8 @@ func TestNewRTCBundlePolicy(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCBundlePolicy(testCase.policyString),
 			testCase.expectedPolicy,
+			newRTCBundlePolicy(testCase.policyString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -39,8 +39,8 @@ func TestRTCBundlePolicy_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.policy.String(),
 			testCase.expectedString,
+			testCase.policy.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcdatachannelstate.go
+++ b/rtcdatachannelstate.go
@@ -30,9 +30,7 @@ const (
 	rtcDataChannelStateClosedStr     = "closed"
 )
 
-// NewRTCDataChannelState defines a procedure for creating a new
-// RTCDataChannelState from a raw string naming the data chanenel state.
-func NewRTCDataChannelState(raw string) RTCDataChannelState {
+func newRTCDataChannelState(raw string) RTCDataChannelState {
 	switch raw {
 	case rtcDataChannelStateConnectingStr:
 		return RTCDataChannelStateConnecting

--- a/rtcdatachannelstate_test.go
+++ b/rtcdatachannelstate_test.go
@@ -20,8 +20,8 @@ func TestNewRTCDataChannelState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCDataChannelState(testCase.stateString),
 			testCase.expectedState,
+			newRTCDataChannelState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -41,8 +41,8 @@ func TestRTCDataChannelState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcdtlstransportstate.go
+++ b/rtcdtlstransportstate.go
@@ -36,9 +36,7 @@ const (
 	rtcDtlsTransportStateFailedStr     = "failed"
 )
 
-// NewRTCDtlsTransportState defines a procedure for creating a new
-// RTCDtlsTransportState from a raw string naming the transport state.
-func NewRTCDtlsTransportState(raw string) RTCDtlsTransportState {
+func newRTCDtlsTransportState(raw string) RTCDtlsTransportState {
 	switch raw {
 	case rtcDtlsTransportStateNewStr:
 		return RTCDtlsTransportStateNew

--- a/rtcdtlstransportstate_test.go
+++ b/rtcdtlstransportstate_test.go
@@ -21,8 +21,8 @@ func TestNewRTCDtlsTransportState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCDtlsTransportState(testCase.stateString),
 			testCase.expectedState,
+			newRTCDtlsTransportState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -43,8 +43,8 @@ func TestRTCDtlsTransportState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcicecandidatetype.go
+++ b/rtcicecandidatetype.go
@@ -1,0 +1,70 @@
+package webrtc
+
+// RTCIceCandidateType represents the type of the ICE candidate used.
+type RTCIceCandidateType int
+
+const (
+	// RTCIceCandidateTypeHost indicates that the candidate is of Host type as
+	// described in https://tools.ietf.org/html/rfc8445#section-5.1.1.1. A
+	// candidate obtained by binding to a specific port from an IP address on
+	// the host. This includes IP addresses on physical interfaces and logical
+	// ones, such as ones obtained through VPNs.
+	RTCIceCandidateTypeHost RTCIceCandidateType = iota + 1
+
+	// RTCIceCandidateTypeSrflx indicates the the candidate is of Server
+	// Reflexive type as described
+	// https://tools.ietf.org/html/rfc8445#section-5.1.1.2. A candidate type
+	// whose IP address and port are a binding allocated by a NAT for an ICE
+	// agent after it sends a packet through the NAT to a server, such as a
+	// STUN server.
+	RTCIceCandidateTypeSrflx
+
+	// RTCIceCandidateTypePrflx indicates that the candidate is of Peer
+	// Reflexive type. A candidate type whose IP address and port are a binding
+	// allocated by a NAT for an ICE agent after it sends a packet through the
+	// NAT to its peer.
+	RTCIceCandidateTypePrflx
+
+	// RTCIceCandidateTypeRelay indicates the the candidate is of Relay type as
+	// described in https://tools.ietf.org/html/rfc8445#section-5.1.1.2. A
+	// candidate type obtained from a relay server, such as a TURN server.
+	RTCIceCandidateTypeRelay
+)
+
+// This is done this way because of a linter.
+const (
+	rtcIceCandidateTypeHostStr  = "host"
+	rtcIceCandidateTypeSrflxStr = "srflx"
+	rtcIceCandidateTypePrflxStr = "prflx"
+	rtcIceCandidateTypeRelayStr = "relay"
+)
+
+func newRTCIceCandidateType(raw string) RTCIceCandidateType {
+	switch raw {
+	case rtcIceCandidateTypeHostStr:
+		return RTCIceCandidateTypeHost
+	case rtcIceCandidateTypeSrflxStr:
+		return RTCIceCandidateTypeSrflx
+	case rtcIceCandidateTypePrflxStr:
+		return RTCIceCandidateTypePrflx
+	case rtcIceCandidateTypeRelayStr:
+		return RTCIceCandidateTypeRelay
+	default:
+		return RTCIceCandidateType(Unknown)
+	}
+}
+
+func (t RTCIceCandidateType) String() string {
+	switch t {
+	case RTCIceCandidateTypeHost:
+		return rtcIceCandidateTypeHostStr
+	case RTCIceCandidateTypeSrflx:
+		return rtcIceCandidateTypeSrflxStr
+	case RTCIceCandidateTypePrflx:
+		return rtcIceCandidateTypePrflxStr
+	case RTCIceCandidateTypeRelay:
+		return rtcIceCandidateTypeRelayStr
+	default:
+		return ErrUnknownType.Error()
+	}
+}

--- a/rtcicecandidatetype_test.go
+++ b/rtcicecandidatetype_test.go
@@ -1,0 +1,49 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRTCIceCandidateType(t *testing.T) {
+	testCases := []struct {
+		typeString   string
+		expectedType RTCIceCandidateType
+	}{
+		{"unknown", RTCIceCandidateType(Unknown)},
+		{"host", RTCIceCandidateTypeHost},
+		{"srflx", RTCIceCandidateTypeSrflx},
+		{"prflx", RTCIceCandidateTypePrflx},
+		{"relay", RTCIceCandidateTypeRelay},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedType,
+			newRTCIceCandidateType(testCase.typeString),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestRTCIceCandidateType_String(t *testing.T) {
+	testCases := []struct {
+		cType          RTCIceCandidateType
+		expectedString string
+	}{
+		{RTCIceCandidateType(Unknown), "unknown"},
+		{RTCIceCandidateTypeHost, "host"},
+		{RTCIceCandidateTypeSrflx, "srflx"},
+		{RTCIceCandidateTypePrflx, "prflx"},
+		{RTCIceCandidateTypeRelay, "relay"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.cType.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/rtcicecomponent.go
+++ b/rtcicecomponent.go
@@ -1,0 +1,47 @@
+package webrtc
+
+// RTCIceComponent describes if the ice transport is used for RTP
+// (or RTCP multiplexing).
+type RTCIceComponent int
+
+const (
+	// RTCIceComponentRtp indicates that the ICE Transport is used for RTP (or
+	// RTCP multiplexing), as defined in
+	// https://tools.ietf.org/html/rfc5245#section-4.1.1.1. Protocols
+	// multiplexed with RTP (e.g. data channel) share its component ID. This
+	// represents the component-id value 1 when encoded in candidate-attribute.
+	RTCIceComponentRtp RTCIceComponent = iota + 1
+
+	// RTCIceComponentRtcp indicates that the ICE Transport is used for RTCP as
+	// defined by https://tools.ietf.org/html/rfc5245#section-4.1.1.1. This
+	// represents the component-id value 2 when encoded in candidate-attribute.
+	RTCIceComponentRtcp
+)
+
+// This is done this way because of a linter.
+const (
+	rtcIceComponentRtpStr  = "rtp"
+	rtcIceComponentRtcpStr = "rtcp"
+)
+
+func newRTCIceComponent(raw string) RTCIceComponent {
+	switch raw {
+	case rtcIceComponentRtpStr:
+		return RTCIceComponentRtp
+	case rtcIceComponentRtcpStr:
+		return RTCIceComponentRtcp
+	default:
+		return RTCIceComponent(Unknown)
+	}
+}
+
+func (t RTCIceComponent) String() string {
+	switch t {
+	case RTCIceComponentRtp:
+		return rtcIceComponentRtpStr
+	case RTCIceComponentRtcp:
+		return rtcIceComponentRtcpStr
+	default:
+		return ErrUnknownType.Error()
+	}
+}

--- a/rtcicecomponent_test.go
+++ b/rtcicecomponent_test.go
@@ -1,0 +1,45 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRTCIceComponent(t *testing.T) {
+	testCases := []struct {
+		componentString   string
+		expectedComponent RTCIceComponent
+	}{
+		{"unknown", RTCIceComponent(Unknown)},
+		{"rtp", RTCIceComponentRtp},
+		{"rtcp", RTCIceComponentRtcp},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			newRTCIceComponent(testCase.componentString),
+			testCase.expectedComponent,
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestRTCIceComponent_String(t *testing.T) {
+	testCases := []struct {
+		state          RTCIceComponent
+		expectedString string
+	}{
+		{RTCIceComponent(Unknown), "unknown"},
+		{RTCIceComponentRtp, "rtp"},
+		{RTCIceComponentRtcp, "rtcp"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.state.String(),
+			testCase.expectedString,
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/rtciceconnectionstate.go
+++ b/rtciceconnectionstate.go
@@ -50,9 +50,7 @@ const (
 	rtcIceConnectionStateClosedStr       = "closed"
 )
 
-// NewRTCIceConnectionState defines a procedure for creating a new
-// RTCIceConnectionState from a raw string naming the signaling state.
-func NewRTCIceConnectionState(raw string) RTCIceConnectionState {
+func newRTCIceConnectionState(raw string) RTCIceConnectionState {
 	switch raw {
 	case rtcIceConnectionStateNewStr:
 		return RTCIceConnectionStateNew

--- a/rtciceconnectionstate_test.go
+++ b/rtciceconnectionstate_test.go
@@ -23,8 +23,8 @@ func TestNewRTCIceConnectionState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCIceConnectionState(testCase.stateString),
 			testCase.expectedState,
+			newRTCIceConnectionState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -47,8 +47,8 @@ func TestRTCIceConnectionState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcicecredentialtype.go
+++ b/rtcicecredentialtype.go
@@ -20,9 +20,7 @@ const (
 	rtcIceCredentialTypeOauthStr    = "oauth"
 )
 
-// NewRTCIceCredentialType defines a procedure for creating a new
-// RTCIceCredentialType from a raw string naming the ice credential type.
-func NewRTCIceCredentialType(raw string) RTCIceCredentialType {
+func newRTCIceCredentialType(raw string) RTCIceCredentialType {
 	switch raw {
 	case rtcIceCredentialTypePasswordStr:
 		return RTCIceCredentialTypePassword

--- a/rtcicecredentialtype_test.go
+++ b/rtcicecredentialtype_test.go
@@ -18,8 +18,8 @@ func TestNewRTCIceCredentialType(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCIceCredentialType(testCase.credentialTypeString),
 			testCase.expectedCredentialType,
+			newRTCIceCredentialType(testCase.credentialTypeString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -37,8 +37,8 @@ func TestRTCIceCredentialType_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.credentialType.String(),
 			testCase.expectedString,
+			testCase.credentialType.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcicegatheringstate.go
+++ b/rtcicegatheringstate.go
@@ -25,9 +25,7 @@ const (
 	rtcIceGatheringStateCompleteStr  = "complete"
 )
 
-// NewRTCIceGatheringState defines a procedure for creating a new
-// RTCIceGatheringState from a raw string naming the gathering state.
-func NewRTCIceGatheringState(raw string) RTCIceGatheringState {
+func newRTCIceGatheringState(raw string) RTCIceGatheringState {
 	switch raw {
 	case rtcIceGatheringStateNewStr:
 		return RTCIceGatheringStateNew

--- a/rtcicegatheringstate_test.go
+++ b/rtcicegatheringstate_test.go
@@ -19,8 +19,8 @@ func TestNewRTCIceGatheringState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCIceGatheringState(testCase.stateString),
 			testCase.expectedState,
+			newRTCIceGatheringState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -39,8 +39,8 @@ func TestRTCIceGatheringState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtciceprotocol.go
+++ b/rtciceprotocol.go
@@ -1,0 +1,41 @@
+package webrtc
+
+// RTCIceProtocol indicates the transport protocol type that is used in the
+// ice.URL structure.
+type RTCIceProtocol int
+
+const (
+	// RTCIceProtocolUDP indicates the URL uses a UDP transport.
+	RTCIceProtocolUDP RTCIceProtocol = iota + 1
+
+	// RTCIceProtocolTCP indicates the URL uses a TCP transport.
+	RTCIceProtocolTCP
+)
+
+// This is done this way because of a linter.
+const (
+	rtcIceProtocolUDPStr = "udp"
+	rtcIceProtocolTCPStr = "tcp"
+)
+
+func newRTCIceProtocol(raw string) RTCIceProtocol {
+	switch raw {
+	case rtcIceProtocolUDPStr:
+		return RTCIceProtocolUDP
+	case rtcIceProtocolTCPStr:
+		return RTCIceProtocolTCP
+	default:
+		return RTCIceProtocol(Unknown)
+	}
+}
+
+func (t RTCIceProtocol) String() string {
+	switch t {
+	case RTCIceProtocolUDP:
+		return rtcIceProtocolUDPStr
+	case RTCIceProtocolTCP:
+		return rtcIceProtocolTCPStr
+	default:
+		return ErrUnknownType.Error()
+	}
+}

--- a/rtciceprotocol_test.go
+++ b/rtciceprotocol_test.go
@@ -1,0 +1,45 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRTCIceProtocol(t *testing.T) {
+	testCases := []struct {
+		protoString   string
+		expectedProto RTCIceProtocol
+	}{
+		{"unknown", RTCIceProtocol(Unknown)},
+		{"udp", RTCIceProtocolUDP},
+		{"tcp", RTCIceProtocolTCP},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedProto,
+			newRTCIceProtocol(testCase.protoString),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestRTCIceProtocol_String(t *testing.T) {
+	testCases := []struct {
+		proto          RTCIceProtocol
+		expectedString string
+	}{
+		{RTCIceProtocol(Unknown), "unknown"},
+		{RTCIceProtocolUDP, "udp"},
+		{RTCIceProtocolTCP, "tcp"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.proto.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/rtcicerole.go
+++ b/rtcicerole.go
@@ -1,0 +1,45 @@
+package webrtc
+
+// RTCIceRole describes the role ice.Agent is playing in selecting the
+// preferred the candidate pair.
+type RTCIceRole int
+
+const (
+	// RTCIceRoleControlling indicates that the ICE agent that is responsible
+	// for selecting the final choice of candidate pairs and signaling them
+	// through STUN and an updated offer, if needed. In any session, one agent
+	// is always controlling. The other is the controlled agent.
+	RTCIceRoleControlling RTCIceRole = iota + 1
+
+	// RTCIceRoleControlled indicates that an ICE agent that waits for the
+	// controlling agent to select the final choice of candidate pairs.
+	RTCIceRoleControlled
+)
+
+// This is done this way because of a linter.
+const (
+	rtcIceRoleControllingStr = "controlling"
+	rtcIceRoleControlledStr  = "controlled"
+)
+
+func newRTCIceRole(raw string) RTCIceRole {
+	switch raw {
+	case rtcIceRoleControllingStr:
+		return RTCIceRoleControlling
+	case rtcIceRoleControlledStr:
+		return RTCIceRoleControlled
+	default:
+		return RTCIceRole(Unknown)
+	}
+}
+
+func (t RTCIceRole) String() string {
+	switch t {
+	case RTCIceRoleControlling:
+		return rtcIceRoleControllingStr
+	case RTCIceRoleControlled:
+		return rtcIceRoleControlledStr
+	default:
+		return ErrUnknownType.Error()
+	}
+}

--- a/rtcicerole_test.go
+++ b/rtcicerole_test.go
@@ -1,0 +1,45 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRTCIceRole(t *testing.T) {
+	testCases := []struct {
+		roleString   string
+		expectedRole RTCIceRole
+	}{
+		{"unknown", RTCIceRole(Unknown)},
+		{"controlling", RTCIceRoleControlling},
+		{"controlled", RTCIceRoleControlled},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedRole,
+			newRTCIceRole(testCase.roleString),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestRTCIceRole_String(t *testing.T) {
+	testCases := []struct {
+		proto          RTCIceRole
+		expectedString string
+	}{
+		{RTCIceRole(Unknown), "unknown"},
+		{RTCIceRoleControlling, "controlling"},
+		{RTCIceRoleControlled, "controlled"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.proto.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/rtcicetransportpolicy.go
+++ b/rtcicetransportpolicy.go
@@ -19,9 +19,7 @@ const (
 	rtcIceTransportPolicyAllStr   = "all"
 )
 
-// NewRTCIceTransportPolicy defines a procedure for creating a new
-// RTCIceTransportPolicy from a raw string naming the ice transport policy.
-func NewRTCIceTransportPolicy(raw string) RTCIceTransportPolicy {
+func newRTCIceTransportPolicy(raw string) RTCIceTransportPolicy {
 	switch raw {
 	case rtcIceTransportPolicyRelayStr:
 		return RTCIceTransportPolicyRelay

--- a/rtcicetransportpolicy_test.go
+++ b/rtcicetransportpolicy_test.go
@@ -18,8 +18,8 @@ func TestNewRTCIceTransportPolicy(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCIceTransportPolicy(testCase.policyString),
 			testCase.expectedPolicy,
+			newRTCIceTransportPolicy(testCase.policyString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -37,8 +37,8 @@ func TestRTCIceTransportPolicy_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.policy.String(),
 			testCase.expectedString,
+			testCase.policy.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcpeerconnectionstate.go
+++ b/rtcpeerconnectionstate.go
@@ -44,9 +44,7 @@ const (
 	rtcPeerConnectionStateClosedStr       = "closed"
 )
 
-// NewRTCPeerConnectionState defines a procedure for creating a new
-// RTCPeerConnectionState from a raw string naming the peer connection state.
-func NewRTCPeerConnectionState(raw string) RTCPeerConnectionState {
+func newRTCPeerConnectionState(raw string) RTCPeerConnectionState {
 	switch raw {
 	case rtcPeerConnectionStateNewStr:
 		return RTCPeerConnectionStateNew

--- a/rtcpeerconnectionstate_test.go
+++ b/rtcpeerconnectionstate_test.go
@@ -22,8 +22,8 @@ func TestNewRTCPeerConnectionState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCPeerConnectionState(testCase.stateString),
 			testCase.expectedState,
+			newRTCPeerConnectionState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -45,8 +45,8 @@ func TestRTCPeerConnectionState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcprioritytype.go
+++ b/rtcprioritytype.go
@@ -25,9 +25,7 @@ const (
 	rtcPriorityTypeHighStr    = "high"
 )
 
-// NewRTCPriorityType defines a procedure for creating a new RTCPriorityType
-// from a raw string naming the priority type.
-func NewRTCPriorityType(raw string) RTCPriorityType {
+func newRTCPriorityTypeFromString(raw string) RTCPriorityType {
 	switch raw {
 	case rtcPriorityTypeVeryLowStr:
 		return RTCPriorityTypeVeryLow
@@ -36,6 +34,21 @@ func NewRTCPriorityType(raw string) RTCPriorityType {
 	case rtcPriorityTypeMediumStr:
 		return RTCPriorityTypeMedium
 	case rtcPriorityTypeHighStr:
+		return RTCPriorityTypeHigh
+	default:
+		return RTCPriorityType(Unknown)
+	}
+}
+
+func newRTCPriorityTypeFromUint16(raw uint16) RTCPriorityType {
+	switch {
+	case raw <= 128:
+		return RTCPriorityTypeVeryLow
+	case 129 <= raw && raw <= 256:
+		return RTCPriorityTypeLow
+	case 257 <= raw && raw <= 512:
+		return RTCPriorityTypeMedium
+	case 513 <= raw:
 		return RTCPriorityTypeHigh
 	default:
 		return RTCPriorityType(Unknown)

--- a/rtcprioritytype_test.go
+++ b/rtcprioritytype_test.go
@@ -9,19 +9,31 @@ import (
 func TestNewRTCPriorityType(t *testing.T) {
 	testCases := []struct {
 		priorityString   string
+		priorityUint16   uint16
 		expectedPriority RTCPriorityType
 	}{
-		{"unknown", RTCPriorityType(Unknown)},
-		{"very-low", RTCPriorityTypeVeryLow},
-		{"low", RTCPriorityTypeLow},
-		{"medium", RTCPriorityTypeMedium},
-		{"high", RTCPriorityTypeHigh},
+		{"unknown", 0, RTCPriorityType(Unknown)},
+		{"very-low", 100, RTCPriorityTypeVeryLow},
+		{"low", 200, RTCPriorityTypeLow},
+		{"medium", 300, RTCPriorityTypeMedium},
+		{"high", 1000, RTCPriorityTypeHigh},
 	}
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCPriorityType(testCase.priorityString),
 			testCase.expectedPriority,
+			newRTCPriorityTypeFromString(testCase.priorityString),
+			"testCase: %d %v", i, testCase,
+		)
+
+		// There is no uint that produces generate RTCPriorityType(Unknown).
+		if i == 0 {
+			continue
+		}
+
+		assert.Equal(t,
+			testCase.expectedPriority,
+			newRTCPriorityTypeFromUint16(testCase.priorityUint16),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -41,8 +53,8 @@ func TestRTCPriorityType_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.priority.String(),
 			testCase.expectedString,
+			testCase.priority.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcrtcpmuxpolicy.go
+++ b/rtcrtcpmuxpolicy.go
@@ -23,9 +23,7 @@ const (
 	rtcRtcpMuxPolicyRequireStr   = "require"
 )
 
-// NewRTCRtcpMuxPolicy defines a procedure for creating a new RTCRtcpMuxPolicy
-// from a raw string naming the rtcp multiplexing policy.
-func NewRTCRtcpMuxPolicy(raw string) RTCRtcpMuxPolicy {
+func newRTCRtcpMuxPolicy(raw string) RTCRtcpMuxPolicy {
 	switch raw {
 	case rtcRtcpMuxPolicyNegotiateStr:
 		return RTCRtcpMuxPolicyNegotiate

--- a/rtcrtcpmuxpolicy_test.go
+++ b/rtcrtcpmuxpolicy_test.go
@@ -18,8 +18,8 @@ func TestNewRTCRtcpMuxPolicy(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCRtcpMuxPolicy(testCase.policyString),
 			testCase.expectedPolicy,
+			newRTCRtcpMuxPolicy(testCase.policyString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -37,8 +37,8 @@ func TestRTCRtcpMuxPolicy_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.policy.String(),
 			testCase.expectedString,
+			testCase.policy.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcsctptransportstate.go
+++ b/rtcsctptransportstate.go
@@ -27,9 +27,7 @@ const (
 	rtcSctpTransportStateClosedStr     = "closed"
 )
 
-// NewRTCSctpTransportState defines a procedure for creating a new
-// RTCSctpTransportState from a raw string naming the transport state.
-func NewRTCSctpTransportState(raw string) RTCSctpTransportState {
+func newRTCSctpTransportState(raw string) RTCSctpTransportState {
 	switch raw {
 	case rtcSctpTransportStateConnectingStr:
 		return RTCSctpTransportStateConnecting

--- a/rtcsctptransportstate_test.go
+++ b/rtcsctptransportstate_test.go
@@ -19,8 +19,8 @@ func TestNewRTCSctpTransportState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCSctpTransportState(testCase.transportStateString),
 			testCase.expectedTransportState,
+			newRTCSctpTransportState(testCase.transportStateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -39,8 +39,8 @@ func TestRTCSctpTransportState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.transportState.String(),
 			testCase.expectedString,
+			testCase.transportState.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcsdptype.go
+++ b/rtcsdptype.go
@@ -41,9 +41,7 @@ const (
 	rtcSdpTypeRollbackStr = "rollback"
 )
 
-// NewRTCSdpType defines a procedure for creating a new RTCSdpType from a raw
-// string naming the session description protocol type.
-func NewRTCSdpType(raw string) RTCSdpType {
+func newRTCSdpType(raw string) RTCSdpType {
 	switch raw {
 	case rtcSdpTypeOfferStr:
 		return RTCSdpTypeOffer

--- a/rtcsdptype_test.go
+++ b/rtcsdptype_test.go
@@ -20,8 +20,8 @@ func TestNewRTCSdpType(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCSdpType(testCase.sdpTypeString),
 			testCase.expectedSdpType,
+			newRTCSdpType(testCase.sdpTypeString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -41,8 +41,8 @@ func TestRTCSdpType_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.sdpType.String(),
 			testCase.expectedString,
+			testCase.sdpType.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}

--- a/rtcsignalingstate.go
+++ b/rtcsignalingstate.go
@@ -41,9 +41,7 @@ const (
 	rtcSignalingStateClosedStr             = "closed"
 )
 
-// NewRTCSignalingState defines a procedure for creating a new
-// RTCSignalingState from a raw string naming the signaling state.
-func NewRTCSignalingState(raw string) RTCSignalingState {
+func newRTCSignalingState(raw string) RTCSignalingState {
 	switch raw {
 	case rtcSignalingStateStableStr:
 		return RTCSignalingStateStable

--- a/rtcsignalingstate_test.go
+++ b/rtcsignalingstate_test.go
@@ -22,8 +22,8 @@ func TestNewRTCSignalingState(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			NewRTCSignalingState(testCase.stateString),
 			testCase.expectedState,
+			newRTCSignalingState(testCase.stateString),
 			"testCase: %d %v", i, testCase,
 		)
 	}
@@ -45,8 +45,8 @@ func TestRTCSignalingState_String(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.state.String(),
 			testCase.expectedString,
+			testCase.state.String(),
 			"testCase: %d %v", i, testCase,
 		)
 	}


### PR DESCRIPTION
This PR just contains a bunch of structures that are needed for the transports internal redesign. The goal here is to break down the transition into small PRs that do not break the library.