### PR TITLE
Add getIceServers to support easy server parsing

### DIFF
--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -1,5 +1,9 @@
 package webrtc
 
+import (
+	"github.com/pions/webrtc/pkg/ice"
+)
+
 // RTCConfiguration defines a set of parameters to configure how the
 // peer-to-peer communication via RTCPeerConnection is established or
 // re-established.
@@ -40,4 +44,18 @@ type RTCConfiguration struct {
 
 	// IceCandidatePoolSize describes the size of the prefetched ICE pool.
 	IceCandidatePoolSize uint8
+}
+
+func (c RTCConfiguration) getIceServers() (*[]*ice.URL, error) {
+	var iceServers []*ice.URL
+	for _, server := range c.IceServers {
+		for _, rawURL := range server.URLs {
+			url, err := ice.ParseURL(rawURL)
+			if err != nil {
+				return nil, err
+			}
+			iceServers = append(iceServers, url)
+		}
+	}
+	return &iceServers, nil
 }

--- a/rtcconfiguration_test.go
+++ b/rtcconfiguration_test.go
@@ -1,0 +1,38 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRTCConfiguration_getIceServers(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		expectedServerStr := "stun:stun.l.google.com:19302"
+		cfg := RTCConfiguration{
+			IceServers: []RTCIceServer{
+				{
+					URLs: []string{expectedServerStr},
+				},
+			},
+		}
+
+		parsedURLs, err := cfg.getIceServers()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedServerStr, (*parsedURLs)[0].String())
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		expectedServerStr := "stun.l.google.com:19302"
+		cfg := RTCConfiguration{
+			IceServers: []RTCIceServer{
+				{
+					URLs: []string{expectedServerStr},
+				},
+			},
+		}
+
+		_, err := cfg.getIceServers()
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
Tiny PR that only adds one function that is used in later PRs for ease of ice server parsing.

Relates to #83