### PR TITLE
Remove examples directory before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ before_script:
   - go get github.com/mattn/goveralls
 
 script:
+  - bash .github/build-examples.sh
+  - rm -rf examples
+  # Remove examples, no test coverage for them
   - golangci-lint run
-  - goveralls -v -race -covermode=atomic -service=travis-ci -ignore .git,examples
+  - goveralls -v -race -covermode=atomic -service=travis-ci
   - bash .github/assert-contributors.sh
   - bash .github/lint-disallowed-functions-in-library.sh
-  - bash .github/build-examples.sh
   - bash .github/lint-commit-message.sh


### PR DESCRIPTION
We don't write unit tests for examples, exclude them from coveralls

Resolves #147