### PR TITLE
Docs: Improve docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
-# Contributing
+<h1 align="center">
+  Contributing
+</h1>
 
-Moved to [https://github.com/pions/webrtc/wiki/Contributing](https://github.com/pions/webrtc/wiki/Contributing)
+Moved to the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contributing)**.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,35 +1,37 @@
-# Why pion-WebRTC
+<h1 align="center">
+  Design
+</h1>
 WebRTC is a powerful, but complicated technology. You can build amazing things with it comes with a steep learning curve though.
 Using WebRTC in the browser is easy, but outside the browser is more of a challenge. There are multiple libraries, and they all have
 varying levels of quality. Most are also difficult to build, and depend on libraries that aren't available in repos or portable.
 
-pion-WebRTC aims to solve all that! Built in native Go you should be able to send and receive media and text from anywhere with minimal headache.
-These are the design principals that drive pion-WebRTC and hopefully convince you it is worth a try.
+Pion WebRTC aims to solve all that! Built in native Go you should be able to send and receive media and text from anywhere with minimal headache.
+These are the design principals that drive Pion WebRTC and hopefully convince you it is worth a try.
 
-## Portable
-pion-WebRTC is written in Go and extremely portable. Anywhere Golang runs, pion-WebRTC should work as well! Instead of dealing with complicated
+### Portable
+Pion WebRTC is written in Go and extremely portable. Anywhere Golang runs, Pion WebRTC should work as well! Instead of dealing with complicated
 cross-compiling of multiple libraries, you now can run anywhere with one `go build`
 
-## Simple API
-If you know how to use WebRTC in your browser, you know how to use pion-WebRTC.
+### Simple API
+If you know how to use WebRTC in your browser, you know how to use Pion WebRTC.
 We try our best just to duplicate the Javascript API, so your code can look the same everywhere.
 
 If this is your first time using WebRTC, don't worry! We have multiple [examples](https://github.com/pions/webrtc/tree/master/examples) and [GoDoc](https://godoc.org/github.com/pions/webrtc)
 
-## Bring your own media
-pion-WebRTC doesn't make any assumptions about where your audio, video or text come from. You can use FFmpeg, GStreamer, MLT or just serve a video file.
+### Bring your own media
+Pion WebRTC doesn't make any assumptions about where your audio, video or text come from. You can use FFmpeg, GStreamer, MLT or just serve a video file.
 This library only serves to transport, not create media.
 
-## Safe
+### Safe
 Golang provides a great foundation to build safe network services.
 Especially when running a networked service that is highly concurrent bugs can be devastating.
 
-## Readable
+### Readable
 If code comes from an RFC we try to make sure everything is commented with a link to the spec.
 This makes learning and debugging easier, this WebRTC library was written to also serve as a guide for others.
 
-## Tested
+### Tested
 Every commit is tested via travis-ci Go provides fantastic facilities for testing, and more will be added as time goes on.
 
-## Shared libraries
+### Shared libraries
 Every pion product is built using shared libraries, allowing others to review and reuse our libraries.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,37 @@
-# Pion WebRTC
-[![Build Status](https://travis-ci.org/pions/webrtc.svg?branch=master)](https://travis-ci.org/pions/webrtc)
-[![GoDoc](https://godoc.org/github.com/pions/webrtc?status.svg)](https://godoc.org/github.com/pions/webrtc)
-[![Go Report Card](https://goreportcard.com/badge/github.com/pions/webrtc)](https://goreportcard.com/report/github.com/pions/webrtc)
-[![Coverage Status](https://coveralls.io/repos/github/pions/webrtc/badge.svg)](https://coveralls.io/github/pions/webrtc)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/18f4aec384894e6aac0b94effe51961d)](https://www.codacy.com/app/Sean-Der/webrtc)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+<h1 align="center">
+  <a href="https://pion.ly"><img src="./.github/pion-gopher-webrtc.png" alt="Pion WebRTC" height="250px"></a>
+  <br>
+  Pion WebRTC
+  <br>
+</h1>
+<h4 align="center">A Golang implementation of the WebRTC API</h4>
+<br>
+<p align="center">
+  <a href="https://travis-ci.org/pions/webrtc"><img src="https://travis-ci.org/pions/webrtc.svg?branch=master" alt="Build Status"></a>
+  <a href="https://godoc.org/github.com/pions/webrtc"><img src="https://godoc.org/github.com/pions/webrtc?status.svg" alt="GoDoc"></a>
+  <a href="https://goreportcard.com/report/github.com/pions/webrtc"><img src="https://goreportcard.com/badge/github.com/pions/webrtc" alt="Go Report Card"></a>
+  <a href="https://coveralls.io/github/pions/webrtc"><img src="https://coveralls.io/repos/github/pions/webrtc/badge.svg" alt="Coverage Status"></a>
+  <a href="https://www.codacy.com/app/Sean-Der/webrtc"><img src="https://api.codacy.com/project/badge/Grade/18f4aec384894e6aac0b94effe51961d" alt="Codacy Badge"></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+</p>
+<br>
 
-<div align="center">
-    <a href="#">
-        <img src="./.github/pion-gopher-webrtc.png" height="300px">
-    </a>
-</div>
+See [DESIGN.md](DESIGN.md) for an overview of features and future goals.
 
-A Golang implementation of the WebRTC API.
-
-See [DESIGN.md](DESIGN.md) for the features it offers, and future goals.
-
-## Getting Started
-This project provides a Go implementation of the WebRTC API. There isn't a application that will fit all your needs, but we provide a
-few simple examples to show common use cases that you are free to modify and extend to your needs.
-
-### What can I build with pion-WebRTC?
-pion-WebRTC is here to help you get media/text from A<->B, here are some of the cool things you could build.
-
-* Send a video file to multiple browser in real time, perfectly synchronized movie watching.
-* Send a webcam on a small device to your browser, with no additional server required
-* Securely send data between two servers, without using pub/sub
-* Record your webcam and do special effects server side
-* Build a conferencing application that processes audio/video and make decisions off of it
-
-### Prerequisites
-We still use OpenSSL for DTLS (we are actively working on replacing it) so make sure to install the OpenSSL headers for
-your platform before using pion-WebRTC.
+### Install
+Currently Pion uses CGO and OpenSSL for DTLS. We are actively working on replacing it. For now you have to make sure to install a C compliler and the OpenSSL headers for
+your platform:
 #### Ubuntu/Debian
 `sudo apt-get install libssl-dev`
-
 #### OSX
-
 ```
 brew install openssl
 export CPATH=`brew --prefix`/opt/openssl/include
 export LIBRARY_PATH=`brew --prefix`/opt/openssl/lib
 go get -u github.com/pions/webrtc
 ```
-
 #### Fedora
 `sudo yum install openssl-devel`
-
 #### Windows
 1. Install [mingw-w64](http://mingw-w64.sourceforge.net/)
 2. Install [pkg-config-lite](http://sourceforge.net/projects/pkgconfiglite)
@@ -54,30 +39,35 @@ go get -u github.com/pions/webrtc
 4. Set __PKG\_CONFIG\_PATH__ to the directory containing openssl.pc
    (i.e. c:\mingw64\mingw64\lib\pkgconfig)
 
-### Example Programs
-Examples for common use cases, extend and modify to quickly get started.
-* [gstreamer-receive](examples/gstreamer-receive/README.md) Play video and audio from your Webcam live using GStreamer
-* [gstreamer-send](examples/gstreamer-send/README.md) Send video generated from GStreamer to your browser
-* [save-to-disk](examples/save-to-disk/README.md) Save video from your Webcam to disk
-* [data-channels](examples/data-channels/README.md) Use DataChannels to send text between pion-WebRTC and your browser
+### Usage
+Check out the **[example applications](examples/README.md)** to help you along your Pion WebRTC journey.
 
-### Writing your own application
-The API should match the Javascript WebRTC API, and the [GoDoc](https://godoc.org/github.com/pions/webrtc) is actively maintained
+The Pion WebRTC API closely matches the JavaScript **[WebRTC API](https://w3c.github.io/webrtc-pc/)**. Most existing documentation is therefore also usefull when working with Pion. Furthermore, our **[GoDoc](https://godoc.org/github.com/pions/webrtc)** is actively maintained.
 
-## Roadmap
-pion-WebRTC is in active development, you can find the roadmap [here](https://github.com/pions/webrtc/issues/9).
+Now go forth and build some awesome apps! Here are some **ideas** to get your creative juices flowing:
+* Send a video file to multiple browser in real time for perfectly synchronized movie watching.
+* Send a webcam on an embedded device to your browser with no additional server required!
+* Securely send data between two servers, without using pub/sub.
+* Record your webcam and do special effects server side.
+* Build a conferencing application that processes audio/video and make decisions off of it.
 
-## Questions/Support
-Sign up for the [Golang Slack](https://invite.slack.golangbridge.org/) and join the #pion channel for discussions and support
+### Roadmap
+The library is in active development, please refer to the [roadmap](https://github.com/pions/webrtc/issues/9) to track our major milestones.
 
-You can also use [Pion mailing list](https://groups.google.com/forum/#!forum/pion)
+### Community
+Pion has an active community on the [Golang Slack](https://invite.slack.golangbridge.org/). Sign up and join the **#pion** channel for discussions and support. You can also use [Pion mailing list](https://groups.google.com/forum/#!forum/pion).
 
-If you need commercial support/don't want to use public methods you can contact us at [team@pion.ly](mailto:team@pion.ly)
+We are always looking to support **your projects**. Please reach out if you have something to build!
 
-## Contributing
-See [Contributing](https://github.com/pions/webrtc/wiki/Contributing)
+If you need commercial support or don't want to use public methods you can contact us at [team@pion.ly](mailto:team@pion.ly)
 
-### Contributors
+### Related projects
+* [pions/turn](https://github.com/pions/turn): A simple extendable Golang TURN server
+* [WIP] [pions/media-server](https://github.com/pions/media-server): A Pion WebRTC powered media server, providing the building blocks for anything RTC.
+* [WIP] [pions/dcnet](https://github.com/pions/dcnet): A package providing Golang [net](https://godoc.org/net) interfaces around Pion WebRTC data channels. 
+
+### Contributing
+Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contributing)** to join the group of amazing people making this project possible:
 
 * [John Bradley](https://github.com/kc5nra) - *Original Author*
 * [Michael Melvin Santry](https://github.com/santrym) - *Mascot*
@@ -91,14 +81,5 @@ See [Contributing](https://github.com/pions/webrtc/wiki/Contributing)
 * [wattanakorn495](https://github.com/wattanakorn495)
 * [Max Hawkins](https://github.com/maxhawkins) - *RTCP*
 
-
-## Project Ideas
-We are looking to support other interesting WebRTC projects, so if you have something to build please reach out!
-pion-WebRTC would make a great foundation for.
-
-* Easy language bindings (Python)
-* Golang SFU
-* Server side processing (video effects or an MCU)
-
-## License
+### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,19 @@
-# Examples
-This directory contains some example use-cases of Pions WebRTC.
+<h1 align="center">
+  Examples
+</h1>
 
-## Instructions
-You can host the examples locally on your machine as follows:
+We've build an extensive collection of examples covering common use-cases. Modify and extend these examples to quickly get started.
+
+* [gstreamer-receive](examples/gstreamer-receive/README.md): Play video and audio from your Webcam live using GStreamer
+* [gstreamer-send](examples/gstreamer-send/README.md): Send video generated from GStreamer to your browser
+* [save-to-disk](examples/save-to-disk/README.md): Save video from your Webcam to disk
+* [data-channels](examples/data-channels/README.md): Use data channels to send text between Pion WebRTC and your browser
+* [data-channels-create](examples/data-channels/README.md): Similar to data channels but now Pion initiates the creation of the data channel.
+* [WIP] [pion-to-pion](examples/pion-to-pion/README.md): An example of two Pion instances communicating directly.
+
+All examples can be executed on your local machine.
+
+### Install
 ``` sh
 go get github.com/pions/webrtc
 cd $GOPATH/src/github.com/pions/webrtc/examples


### PR DESCRIPTION
Goals:
- Link to the examples from the main README.
- Draw attention to the things that matter most.
- Liven the docs up a bit but keep it minimal.

Possible future improvements:
- Replace the entire 'install' section with `go get github.com/pions/webrtc`.
- Remove the roadmap section when things stabilize.
- Maybe create a pions/awesome-webrtc to feature other peoples projects.