### PR TITLE
Fix deprecation cutover, and bad SDP creation

### DIFF
--- a/examples/data-channels/main.go
+++ b/examples/data-channels/main.go
@@ -61,7 +61,7 @@ func main() {
 	datachannels := make([]*webrtc.RTCDataChannel, 0)
 	var dataChannelsLock sync.RWMutex
 
-	peerConnection.Ondatachannel = func(d *webrtc.RTCDataChannel) {
+	peerConnection.OnDataChannel = func(d *webrtc.RTCDataChannel) {
 		dataChannelsLock.Lock()
 		datachannels = append(datachannels, d)
 		dataChannelsLock.Unlock()

--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
 	// for the given codec
-	peerConnection.Ontrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
 		codec := track.Codec
 		fmt.Printf("Track has started, of type %d: %s \n", track.PayloadType, codec.Name)
 		pipeline := gst.CreatePipeline(codec.Name)

--- a/examples/pion-to-pion/offer/main.go
+++ b/examples/pion-to-pion/offer/main.go
@@ -26,7 +26,7 @@ func buildPeerConnection() *webrtc.RTCPeerConnection {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	}
 
-	peerConnection.Ondatachannel = func(d *webrtc.RTCDataChannel) {
+	peerConnection.OnDataChannel = func(d *webrtc.RTCDataChannel) {
 		fmt.Printf("New DataChannel %s %d\n", d.Label, d.ID)
 
 		d.Lock()

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -47,7 +47,7 @@ func main() {
 	// Set a handler for when a new remote track starts, this handler saves buffers to disk as
 	// an ivf file, since we could have multiple video tracks we provide a counter.
 	// In your application this is where you would handle/process video
-	peerConnection.Ontrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
 		if track.Codec.Name == webrtc.VP8 {
 			fmt.Println("Got VP8 track, saving to disk as output.ivf")
 			i, err := ivfwriter.New("output.ivf")


### PR DESCRIPTION
Methods that were marked as deprecated weren't properly handled. There
was a mix of old+new ones supported which caused broken behavior.

SDP creation didn't add SCTP to Offer

Resolves #156