### PR TITLE
[WIP] DataChannels: Open channels

### DIFF
--- a/examples/data-channels-create/main.go
+++ b/examples/data-channels-create/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"time"
@@ -35,19 +36,24 @@ func main() {
 	// This will notify you when the peer has connected/disconnected
 	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
+	}
 
-		// TODO: find the correct place for this
-		if connectionState == ice.ConnectionStateConnected {
-			fmt.Println("sending openchannel")
-			err := dataChannel.SendOpenChannelMessage()
-			if err != nil {
-				fmt.Println("faild to send openchannel", err)
-			}
+	dataChannel.Lock()
+
+	// Register channel opening handling
+	dataChannel.OnOpen = func() {
+		fmt.Printf("Data channel %s %d open. Random messages will now be sent to any connected DataChannels every 5 seconds", dataChannel.Label, dataChannel.ID)
+		for {
+			time.Sleep(5 * time.Second)
+			message := randSeq(15)
+			fmt.Printf("Sending %s \n", message)
+
+			err := dataChannel.Send(datachannel.PayloadString{Data: []byte(message)})
+			check(err)
 		}
 	}
 
 	// Register the Onmessage to handle incoming messages
-	dataChannel.Lock()
 	dataChannel.Onmessage = func(payload datachannel.Payload) {
 		switch p := payload.(type) {
 		case *datachannel.PayloadString:
@@ -58,6 +64,7 @@ func main() {
 			fmt.Printf("Message '%s' from DataChannel '%s' no payload \n", p.PayloadType().String(), dataChannel.Label)
 		}
 	}
+
 	dataChannel.Unlock()
 
 	// Create an offer to send to the browser
@@ -67,7 +74,7 @@ func main() {
 	// Output the offer in base64 so we can paste it in browser
 	fmt.Println(base64.StdEncoding.EncodeToString([]byte(offer.Sdp)))
 
-	// Wait for the offer to be pasted
+	// Wait for the answer to be pasted
 	sd := mustReadStdin()
 
 	// Set the remote SessionDescription
@@ -80,15 +87,8 @@ func main() {
 	err = peerConnection.SetRemoteDescription(answer)
 	check(err)
 
-	// Send messages every 5 seconds
-	fmt.Println("Random messages will now be sent to any connected DataChannels every 5 seconds")
+	// Block forever
 	for {
-		time.Sleep(5 * time.Second)
-		message := randSeq(15)
-		fmt.Printf("Sending %s \n", message)
-
-		err := dataChannel.Send(datachannel.PayloadString{Data: []byte(message)})
-		check(err)
 	}
 }
 
@@ -107,12 +107,15 @@ func randSeq(n int) string {
 func mustReadStdin() string {
 	reader := bufio.NewReader(os.Stdin)
 	rawSd, err := reader.ReadString('\n')
-	check(err)
+	if err != io.EOF {
+		check(err)
+	}
 
 	fmt.Println("")
-	sd, err := base64.StdEncoding.DecodeString(rawSd)
 
+	sd, err := base64.StdEncoding.DecodeString(rawSd)
 	check(err)
+
 	return string(sd)
 }
 

--- a/examples/data-channels-create/main.go
+++ b/examples/data-channels-create/main.go
@@ -88,8 +88,7 @@ func main() {
 	check(err)
 
 	// Block forever
-	for {
-	}
+	select {}
 }
 
 // randSeq is used to generate a random message

--- a/examples/data-channels/main.go
+++ b/examples/data-channels/main.go
@@ -89,8 +89,7 @@ func main() {
 	fmt.Println(base64.StdEncoding.EncodeToString([]byte(answer.Sdp)))
 
 	// Block forever
-	for {
-	}
+	select {}
 }
 
 func randSeq(n int) string {

--- a/examples/data-channels/main.go
+++ b/examples/data-channels/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/pions/webrtc"
@@ -15,42 +14,24 @@ import (
 	"github.com/pions/webrtc/pkg/ice"
 )
 
-func randSeq(n int) string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[r.Intn(len(letters))]
-	}
-	return string(b)
-}
-
 func main() {
-	reader := bufio.NewReader(os.Stdin)
-	rawSd, err := reader.ReadString('\n')
-	if err != nil && err != io.EOF {
-		panic(err)
-	}
-
-	fmt.Println("")
-	sd, err := base64.StdEncoding.DecodeString(rawSd)
-	if err != nil {
-		panic(err)
-	}
+	// Wait for the offer to be pasted
+	sd := mustReadStdin()
 
 	/* Everything below is the pion-WebRTC API, thanks for using it! */
 
-	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(webrtc.RTCConfiguration{
+	// Prepare the configuration
+	config := webrtc.RTCConfiguration{
 		IceServers: []webrtc.RTCIceServer{
 			{
 				URLs: []string{"stun:stun.l.google.com:19302"},
 			},
 		},
-	})
-	if err != nil {
-		panic(err)
 	}
+
+	// Create a new RTCPeerConnection
+	peerConnection, err := webrtc.New(config)
+	check(err)
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
@@ -58,18 +39,27 @@ func main() {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	}
 
-	datachannels := make([]*webrtc.RTCDataChannel, 0)
-	var dataChannelsLock sync.RWMutex
-
+	// Register data channel creation handling
 	peerConnection.OnDataChannel = func(d *webrtc.RTCDataChannel) {
-		dataChannelsLock.Lock()
-		datachannels = append(datachannels, d)
-		dataChannelsLock.Unlock()
-
 		fmt.Printf("New DataChannel %s %d\n", d.Label, d.ID)
 
 		d.Lock()
 		defer d.Unlock()
+
+		// Register channel opening handling
+		d.OnOpen = func() {
+			fmt.Printf("Data channel %s %d open. Random messages will now be sent to any connected DataChannels every 5 seconds", d.Label, d.ID)
+			for {
+				time.Sleep(5 * time.Second)
+				message := randSeq(15)
+				fmt.Printf("Sending %s \n", message)
+
+				err := d.Send(datachannel.PayloadString{Data: []byte(message)})
+				check(err)
+			}
+		}
+
+		// Register message handling
 		d.Onmessage = func(payload datachannel.Payload) {
 			switch p := payload.(type) {
 			case *datachannel.PayloadString:
@@ -87,31 +77,51 @@ func main() {
 		Type: webrtc.RTCSdpTypeOffer,
 		Sdp:  string(sd),
 	}
-	if err := peerConnection.SetRemoteDescription(offer); err != nil {
-		panic(err)
-	}
+
+	err = peerConnection.SetRemoteDescription(offer)
+	check(err)
 
 	// Sets the LocalDescription, and starts our UDP listeners
 	answer, err := peerConnection.CreateAnswer(nil)
-	if err != nil {
-		panic(err)
-	}
+	check(err)
 
 	// Get the LocalDescription and take it to base64 so we can paste in browser
 	fmt.Println(base64.StdEncoding.EncodeToString([]byte(answer.Sdp)))
-	fmt.Println("Random messages will now be sent to any connected DataChannels every 5 seconds")
-	for {
-		time.Sleep(5 * time.Second)
-		message := randSeq(15)
-		fmt.Printf("Sending %s \n", message)
 
-		dataChannelsLock.RLock()
-		for _, d := range datachannels {
-			err := d.Send(datachannel.PayloadString{Data: []byte(message)})
-			if err != nil {
-				panic(err)
-			}
-		}
-		dataChannelsLock.RUnlock()
+	// Block forever
+	for {
+	}
+}
+
+func randSeq(n int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// mustReadStdin blocks untill input is received from stdin
+func mustReadStdin() string {
+	reader := bufio.NewReader(os.Stdin)
+	rawSd, err := reader.ReadString('\n')
+	if err != io.EOF {
+		check(err)
+	}
+
+	fmt.Println("")
+
+	sd, err := base64.StdEncoding.DecodeString(rawSd)
+	check(err)
+
+	return string(sd)
+}
+
+// check is used to panic in an error occurs.
+func check(err error) {
+	if err != nil {
+		panic(err)
 	}
 }

--- a/internal/dtls/dtls.c
+++ b/internal/dtls/dtls.c
@@ -306,7 +306,6 @@ dtls_decrypted *dtls_handle_incoming(dtls_sess *sess, void *buf, int len, char *
   ret->init = finisched;
 
   if (decrypted_len > 1) {
-    fprintf(stderr, "dtls_handle_incoming empty\n");
     ret->buf = decrypted;
     ret->len = decrypted_len;
   }

--- a/internal/dtls/dtls.c
+++ b/internal/dtls/dtls.c
@@ -297,16 +297,18 @@ dtls_decrypted *dtls_handle_incoming(dtls_sess *sess, void *buf, int len, char *
 
   dtls_sess_send_pending(sess, local, remote);
 
-  if (SSL_is_init_finished(sess->ssl)) {
+  int finisched = SSL_is_init_finished(sess->ssl);
+  if (finisched) {
     sess->type = DTLS_CONTYPE_EXISTING;
   }
 
+  ret = (dtls_decrypted *)calloc(1, sizeof(dtls_decrypted));
+  ret->init = finisched;
+
   if (decrypted_len > 1) {
-    ret = (dtls_decrypted *)calloc(1, sizeof(dtls_decrypted));
+    fprintf(stderr, "dtls_handle_incoming empty\n");
     ret->buf = decrypted;
     ret->len = decrypted_len;
-  } else {
-    free(decrypted);
   }
 
   return ret;

--- a/internal/dtls/dtls.h
+++ b/internal/dtls/dtls.h
@@ -40,6 +40,7 @@ typedef struct dtls_sess {
 typedef struct dtls_decrypted {
   void *buf;
   int len;
+  bool init;
 } dtls_decrypted;
 
 #define PROFILE_STRING_LENGTH 23

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -337,6 +337,8 @@ func (m *Manager) SendOpenChannelMessage(streamIdentifier uint16, label string) 
 	if err != nil {
 		return fmt.Errorf("Error Marshaling ChannelOpen %v", err)
 	}
+	m.sctpAssociation.Lock()
+	defer m.sctpAssociation.Unlock()
 	if err = m.sctpAssociation.HandleOutbound(rawMsg, streamIdentifier, sctp.PayloadTypeWebRTCDCEP); err != nil {
 		return fmt.Errorf("Error sending ChannelOpen %v", err)
 	}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -264,8 +264,10 @@ func (m *Manager) dataChannelInboundHandler(data []byte, streamIdentifier uint16
 				return
 			}
 			m.dataChannelEventHandler(&DataChannelCreated{streamIdentifier: streamIdentifier, Label: string(msg.Label)})
+		case *datachannel.ChannelAck:
+			// TODO: handle ChannelAck (https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol-09#section-5.2)
 		default:
-			fmt.Println("Unhandled DataChannel message", m)
+			fmt.Println("Unhandled DataChannel message", msg)
 		}
 	case sctp.PayloadTypeWebRTCString:
 		fallthrough

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -51,3 +51,11 @@ type DataChannelMessage struct {
 func (d *DataChannelMessage) StreamIdentifier() uint16 {
 	return d.streamIdentifier
 }
+
+// DataChannelOpen is emitted when all channels should be opened
+type DataChannelOpen struct{}
+
+// StreamIdentifier returns the streamIdentifier
+func (d *DataChannelOpen) StreamIdentifier() uint16 {
+	return 0
+}

--- a/internal/network/port-receive.go
+++ b/internal/network/port-receive.go
@@ -156,12 +156,17 @@ func (p *port) networkLoop() {
 		}
 
 		// https://tools.ietf.org/html/rfc5764#page-14
+		isICE := false
 		if 127 < in.buffer[0] && in.buffer[0] < 192 {
 			p.handleSRTP(in.buffer)
 		} else if 19 < in.buffer[0] && in.buffer[0] < 64 {
 			p.handleDTLS(in.buffer, in.srcAddr.String())
 		} else if in.buffer[0] < 2 {
 			p.m.IceAgent.HandleInbound(in.buffer, p.listeningAddr, in.srcAddr)
+			isICE = true
+		}
+		if !isICE {
+			p.m.IceAgent.CandidateSeen(in.srcAddr)
 		}
 
 		p.m.certPairLock.RLock()

--- a/internal/sctp/association.go
+++ b/internal/sctp/association.go
@@ -481,33 +481,34 @@ func (a *Association) handleSack(d *chunkSelectiveAck) ([]*packet, error) {
 	return sackDataPackets, nil
 }
 
-func packetDbg(sent bool, p *packet) {
-	dir := "<<<<<"
-	if sent {
-		dir = ">>>>>"
-	}
-
-	res := fmt.Sprintf("SCTP %s", dir)
-	doPrint := false
-	for _, c := range p.chunks {
-		switch c.(type) {
-		case *chunkPayloadData, *chunkSelectiveAck:
-			res += fmt.Sprintf(" %s", c)
-			doPrint = true
-		}
-	}
-
-	if doPrint {
-		fmt.Println(res)
-	}
-}
+// packetDbg can be used to debug the ICE packet flow
+// func packetDbg(sent bool, p *packet) {
+// 	dir := "<<<<<"
+// 	if sent {
+// 		dir = ">>>>>"
+// 	}
+//
+// 	res := fmt.Sprintf("SCTP %s", dir)
+// 	doPrint := false
+// 	for _, c := range p.chunks {
+// 		switch c.(type) {
+// 		case *chunkPayloadData, *chunkSelectiveAck:
+// 			res += fmt.Sprintf(" %s", c)
+// 			doPrint = true
+// 		}
+// 	}
+//
+// 	if doPrint {
+// 		fmt.Println(res)
+// 	}
+// }
 
 func (a *Association) send(p *packet) error {
 	raw, err := p.marshal()
 	if err != nil {
 		return errors.Wrap(err, "Failed to send packet to outbound handler")
 	}
-	packetDbg(true, p)
+	// packetDbg(true, p)
 
 	a.outboundHandler(raw)
 
@@ -515,7 +516,7 @@ func (a *Association) send(p *packet) error {
 }
 
 func (a *Association) handleChunk(p *packet, c chunk) error {
-	packetDbg(false, p)
+	// packetDbg(false, p)
 	if _, err := c.check(); err != nil {
 		return errors.Wrap(err, "Failed validating chunk")
 		// TODO: Create ABORT

--- a/internal/sctp/chunk.go
+++ b/internal/sctp/chunk.go
@@ -150,3 +150,8 @@ type chunk interface {
 
 	valueLength() int
 }
+
+// String makes chunkHeader printable
+func (c chunkHeader) String() string {
+	return c.typ.String()
+}

--- a/internal/sctp/chunk_abort.go
+++ b/internal/sctp/chunk_abort.go
@@ -1,6 +1,8 @@
 package sctp
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -61,4 +63,15 @@ func (a *chunkAbort) marshal() ([]byte, error) {
 
 func (a *chunkAbort) check() (abort bool, err error) {
 	return false, nil
+}
+
+// String makes chunkAbort printable
+func (a *chunkAbort) String() string {
+	res := fmt.Sprintf("%s", a.chunkHeader)
+
+	for _, cause := range a.errorCauses {
+		res += fmt.Sprintf("\n - %s", cause)
+	}
+
+	return res
 }

--- a/internal/sctp/chunk_cookie_ack.go
+++ b/internal/sctp/chunk_cookie_ack.go
@@ -1,6 +1,8 @@
 package sctp
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -36,4 +38,9 @@ func (c *chunkCookieAck) marshal() ([]byte, error) {
 
 func (c *chunkCookieAck) check() (abort bool, err error) {
 	return false, nil
+}
+
+// String makes chunkCookieAck printable
+func (c *chunkCookieAck) String() string {
+	return fmt.Sprintf("%s", c.chunkHeader)
 }

--- a/internal/sctp/chunk_init.go
+++ b/internal/sctp/chunk_init.go
@@ -1,6 +1,8 @@
 package sctp
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -113,4 +115,9 @@ func (i *chunkInit) check() (abort bool, err error) {
 	}
 
 	return false, nil
+}
+
+// String makes chunkInit printable
+func (i *chunkInit) String() string {
+	return fmt.Sprintf("%s\n%s", i.chunkHeader, i.chunkInitCommon)
 }

--- a/internal/sctp/chunk_init_ack.go
+++ b/internal/sctp/chunk_init_ack.go
@@ -1,6 +1,8 @@
 package sctp
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -117,4 +119,9 @@ func (i *chunkInitAck) check() (abort bool, err error) {
 	}
 
 	return false, nil
+}
+
+// String makes chunkInitAck printable
+func (i *chunkInitAck) String() string {
+	return fmt.Sprintf("%s\n%s", i.chunkHeader, i.chunkInitCommon)
 }

--- a/internal/sctp/chunk_init_common.go
+++ b/internal/sctp/chunk_init_common.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -128,4 +129,26 @@ func (i *chunkInitCommon) marshal() ([]byte, error) {
 	}
 
 	return out, nil
+}
+
+// String makes chunkInitCommon printable
+func (i chunkInitCommon) String() string {
+	format := `initiateTag: %d
+	advertisedReceiverWindowCredit: %d
+	numOutboundStreams: %d
+	numInboundStreams: %d
+	initialTSN: %d`
+
+	res := fmt.Sprintf(format,
+		i.initiateTag,
+		i.advertisedReceiverWindowCredit,
+		i.numOutboundStreams,
+		i.numInboundStreams,
+		i.initialTSN,
+	)
+
+	for i, param := range i.params {
+		res = res + fmt.Sprintf("Param %d:\n %s", i, param)
+	}
+	return res
 }

--- a/internal/sctp/chunk_payload_data.go
+++ b/internal/sctp/chunk_payload_data.go
@@ -146,3 +146,8 @@ func (p *chunkPayloadData) marshal() ([]byte, error) {
 func (p *chunkPayloadData) check() (abort bool, err error) {
 	return false, nil
 }
+
+// String makes chunkPayloadData printable
+func (i *chunkPayloadData) String() string {
+	return fmt.Sprintf("%s\n%s", i.chunkHeader, i.tsn)
+}

--- a/internal/sctp/chunk_selective_ack.go
+++ b/internal/sctp/chunk_selective_ack.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -44,6 +45,11 @@ subsequences of DATA chunks as represented by their TSNs.
 type gapAckBlock struct {
 	start uint16
 	end   uint16
+}
+
+// String makes gapAckBlock printable
+func (g gapAckBlock) String() string {
+	return fmt.Sprintf("%d - %d", g.start, g.end)
 }
 
 type chunkSelectiveAck struct {
@@ -119,4 +125,15 @@ func (s *chunkSelectiveAck) marshal() ([]byte, error) {
 
 func (s *chunkSelectiveAck) check() (abort bool, err error) {
 	return false, nil
+}
+
+// String makes chunkSelectiveAck printable
+func (i *chunkSelectiveAck) String() string {
+	res := fmt.Sprintf("%s\n%s", i.chunkHeader, i.cumulativeTSNAck)
+
+	for _, gap := range i.gapAckBlocks {
+		res = fmt.Sprintf("\n gap ack: %s", gap)
+	}
+
+	return res
 }

--- a/internal/sctp/error_cause.go
+++ b/internal/sctp/error_cause.go
@@ -14,6 +14,7 @@ type errorCause interface {
 	unmarshal([]byte) error
 	marshal() ([]byte, error)
 	length() uint16
+	String() string
 
 	errorCauseCode() errorCauseCode
 }

--- a/internal/sctp/error_cause_header.go
+++ b/internal/sctp/error_cause_header.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -35,4 +36,9 @@ func (e *errorCauseHeader) length() uint16 {
 
 func (e *errorCauseHeader) errorCauseCode() errorCauseCode {
 	return e.code
+}
+
+// String makes errorCauseHeader printable
+func (e errorCauseHeader) String() string {
+	return fmt.Sprintf("%s", e.code)
 }

--- a/internal/sctp/error_cause_invalid_mandatory_parameter.go
+++ b/internal/sctp/error_cause_invalid_mandatory_parameter.go
@@ -1,5 +1,7 @@
 package sctp
 
+import "fmt"
+
 // errorCauseInvalidMandatoryParameter represents an SCTP error cause
 type errorCauseInvalidMandatoryParameter struct {
 	errorCauseHeader
@@ -11,4 +13,9 @@ func (e *errorCauseInvalidMandatoryParameter) marshal() ([]byte, error) {
 
 func (e *errorCauseInvalidMandatoryParameter) unmarshal(raw []byte) error {
 	return e.errorCauseHeader.unmarshal(raw)
+}
+
+// String makes errorCauseInvalidMandatoryParameter printable
+func (e *errorCauseInvalidMandatoryParameter) String() string {
+	return fmt.Sprintf("%s", e.errorCauseHeader)
 }

--- a/internal/sctp/error_cause_protocol_violation.go
+++ b/internal/sctp/error_cause_protocol_violation.go
@@ -41,7 +41,10 @@ func (e *errorCauseProtocolViolation) unmarshal(raw []byte) error {
 
 	e.additionalInformation = e.raw
 
-	fmt.Printf("%v", e.additionalInformation)
-	fmt.Printf("%s", string(e.additionalInformation))
 	return nil
+}
+
+// String makes errorCauseProtocolViolation printable
+func (e *errorCauseProtocolViolation) String() string {
+	return fmt.Sprintf("%s: %s", e.errorCauseHeader, e.additionalInformation)
 }

--- a/internal/sctp/error_cause_unrecognized_chunk_type.go
+++ b/internal/sctp/error_cause_unrecognized_chunk_type.go
@@ -1,5 +1,7 @@
 package sctp
 
+import "fmt"
+
 // errorCauseUnrecognizedChunkType represents an SCTP error cause
 type errorCauseUnrecognizedChunkType struct {
 	errorCauseHeader
@@ -11,4 +13,9 @@ func (e *errorCauseUnrecognizedChunkType) marshal() ([]byte, error) {
 
 func (e *errorCauseUnrecognizedChunkType) unmarshal(raw []byte) error {
 	return e.errorCauseHeader.unmarshal(raw)
+}
+
+// String makes errorCauseUnrecognizedChunkType printable
+func (e *errorCauseUnrecognizedChunkType) String() string {
+	return fmt.Sprintf("%s", e.errorCauseHeader)
 }

--- a/internal/sctp/packet.go
+++ b/internal/sctp/packet.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 
 	"github.com/pkg/errors"
@@ -80,6 +81,8 @@ func (p *packet) unmarshal(raw []byte) error {
 			c = &chunkAbort{}
 		case COOKIEECHO:
 			c = &chunkCookieEcho{}
+		case COOKIEACK:
+			c = &chunkCookieAck{}
 		case HEARTBEAT:
 			c = &chunkHeartbeat{}
 		case PAYLOADDATA:
@@ -145,4 +148,22 @@ func generatePacketChecksum(raw []byte) uint32 {
 	}
 
 	return crc32.Checksum(rawCopy, crc32.MakeTable(crc32.Castagnoli))
+}
+
+// String makes packet printable
+func (p *packet) String() string {
+	format := `Packet:
+	sourcePort: %d
+	destinationPort: %d
+	verificationTag: %d
+	`
+	res := fmt.Sprintf(format,
+		p.sourcePort,
+		p.destinationPort,
+		p.verificationTag,
+	)
+	for i, chunk := range p.chunks {
+		res = res + fmt.Sprintf("Chunk %d:\n %s", i, chunk)
+	}
+	return res
 }

--- a/internal/sctp/param_header.go
+++ b/internal/sctp/param_header.go
@@ -1,6 +1,9 @@
 package sctp
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 type paramHeader struct {
 	typ paramType
@@ -34,4 +37,9 @@ func (p *paramHeader) unmarshal(raw []byte) {
 
 func (p *paramHeader) length() int {
 	return p.len
+}
+
+// String makes paramHeader printable
+func (p paramHeader) String() string {
+	return fmt.Sprintf("%s (%d): %s", p.typ, p.len, p.raw)
 }

--- a/internal/sctp/param_state_cookie.go
+++ b/internal/sctp/param_state_cookie.go
@@ -2,6 +2,7 @@ package sctp
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -38,4 +39,9 @@ func (s *paramStateCookie) unmarshal(raw []byte) (param, error) {
 	s.paramHeader.unmarshal(raw)
 	s.cookie = s.raw
 	return s, nil
+}
+
+// String makes paramStateCookie printable
+func (s *paramStateCookie) String() string {
+	return fmt.Sprintf("%s: %s", s.paramHeader, s.cookie)
 }

--- a/internal/sctp/payload_queue.go
+++ b/internal/sctp/payload_queue.go
@@ -1,6 +1,8 @@
 package sctp
 
-import "sort"
+import (
+	"sort"
+)
 
 type payloadDataArray []*chunkPayloadData
 

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -126,6 +126,11 @@ func (a *Agent) pingCandidate(local, remote Candidate) {
 	var msg *stun.Message
 	var err error
 
+	// The controlling agent MUST include the USE-CANDIDATE attribute in
+	// order to nominate a candidate pair (Section 8.1.1).  The controlled
+	// agent MUST NOT include the USE-CANDIDATE attribute in a Binding
+	// request.
+
 	if a.isControlling {
 		msg, err = stun.Build(stun.ClassRequest, stun.MethodBinding, stun.GenerateTransactionId(),
 			&stun.Username{Username: a.remoteUfrag + ":" + a.LocalUfrag},
@@ -137,11 +142,9 @@ func (a *Agent) pingCandidate(local, remote Candidate) {
 			},
 			&stun.Fingerprint{},
 		)
-
 	} else {
 		msg, err = stun.Build(stun.ClassRequest, stun.MethodBinding, stun.GenerateTransactionId(),
 			&stun.Username{Username: a.remoteUfrag + ":" + a.LocalUfrag},
-			&stun.UseCandidate{},
 			&stun.IceControlled{TieBreaker: a.tieBreaker},
 			&stun.Priority{Priority: uint32(local.GetBase().Priority(HostCandidatePreference, 1))},
 			&stun.MessageIntegrity{
@@ -311,9 +314,15 @@ func (a *Agent) handleInboundControlled(m *stun.Message, local *stun.TransportAd
 		return
 	}
 
-	_, useCandidateFound := m.GetOneAttribute(stun.AttrUseCandidate)
-	a.setValidPair(localCandidate, remoteCandidate, useCandidateFound)
-	a.sendBindingSuccess(m, local, remote)
+	successResponse := m.Method == stun.MethodBinding && m.Class == stun.ClassSuccessResponse
+	_, usepair := m.GetOneAttribute(stun.AttrUseCandidate)
+	// Remeber the working pair and select it when marked with usepair
+	a.setValidPair(localCandidate, remoteCandidate, usepair)
+
+	if !successResponse {
+		// Send success response
+		a.sendBindingSuccess(m, local, remote)
+	}
 }
 
 func (a *Agent) handleInboundControlling(m *stun.Message, local *stun.TransportAddr, remote *net.UDPAddr, localCandidate, remoteCandidate Candidate) {
@@ -325,12 +334,31 @@ func (a *Agent) handleInboundControlling(m *stun.Message, local *stun.TransportA
 		return
 	}
 
-	final := m.Class == stun.ClassSuccessResponse && m.Method == stun.MethodBinding
-	a.setValidPair(localCandidate, remoteCandidate, final)
+	successResponse := m.Method == stun.MethodBinding && m.Class == stun.ClassSuccessResponse
+	// Remeber the working pair and select it when receiving a success response
+	a.setValidPair(localCandidate, remoteCandidate, successResponse)
 
-	if !final {
+	if !successResponse {
+		// Send success response
 		a.sendBindingSuccess(m, local, remote)
+
+		// We received a ping from the controlled agent. We know the pair works so now we ping with use-candidate set:
+		a.pingCandidate(localCandidate, remoteCandidate)
 	}
+}
+
+// CandidateSeen is a temporary workaround for missing keep-alive strategy
+func (a *Agent) CandidateSeen(remote *net.UDPAddr) {
+	a.Lock()
+	defer a.Unlock()
+
+	remoteCandidate := getUDPAddrCandidate(a.remoteCandidates, remote)
+	if remoteCandidate == nil {
+		// TODO debug
+		// fmt.Printf("Could not find remote candidate for %s:%d ", remote.IP.String(), remote.Port)
+		return
+	}
+	remoteCandidate.GetBase().LastSeen = time.Now()
 }
 
 // HandleInbound processes traffic from a remote candidate

--- a/rtcdatachannel.go
+++ b/rtcdatachannel.go
@@ -99,6 +99,10 @@ type RTCDataChannel struct {
 	// arrival over the sctp transport from a remote peer.
 	OnMessage func(datachannel.Payload)
 
+	// OnOpen designates an event handler which is invoked when
+	// the underlying data transport has been established (or re-established).
+	OnOpen func()
+
 	// Deprecated: Will be removed when networkManager is deprecated.
 	rtcPeerConnection *RTCPeerConnection
 }

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -817,6 +817,15 @@ func (pc *RTCPeerConnection) dataChannelEventHandler(e network.DataChannelEvent)
 			fmt.Printf("No datachannel found for streamIdentifier %d \n", e.StreamIdentifier())
 
 		}
+	case *network.DataChannelOpen:
+		for _, dc := range pc.dataChannels {
+			dc.Lock()
+			err := dc.SendOpenChannelMessage()
+			if err != nil {
+				fmt.Println("faild to send openchannel", err)
+			}
+			dc.Unlock()
+		}
 	default:
 		fmt.Printf("Unhandled DataChannelEvent %v \n", event)
 	}

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -799,7 +799,10 @@ func (pc *RTCPeerConnection) dataChannelEventHandler(e network.DataChannelEvent)
 		newDataChannel := &RTCDataChannel{ID: &id, Label: event.Label, rtcPeerConnection: pc}
 		pc.dataChannels[e.StreamIdentifier()] = newDataChannel
 		if pc.OnDataChannel != nil {
-			go pc.OnDataChannel(newDataChannel)
+			go func() {
+				pc.OnDataChannel(newDataChannel) // This should actually be called when processing the SDP answer.
+				go newDataChannel.OnOpen()
+			}()
 		} else {
 			fmt.Println("OnDataChannel is unset, discarding message")
 		}
@@ -825,6 +828,8 @@ func (pc *RTCPeerConnection) dataChannelEventHandler(e network.DataChannelEvent)
 				fmt.Println("faild to send openchannel", err)
 			}
 			dc.Unlock()
+
+			go dc.OnOpen()
 		}
 	default:
 		fmt.Printf("Unhandled DataChannelEvent %v \n", event)


### PR DESCRIPTION
The ICE agent now notifies DTLS to start its handshake.
DTLS now notifies SCTP to init.
SCTP now notifies DataChannels to open channels.
The DataChannels now have an OnOpen handler to signal opening of the channel.

TODO:
- [x] Remove the workaround from data-channels-create
- [x] Data over Pions 2 pions data channels 🎉.
- [x] Refactor data-channel examples
- [ ] Make the pions-to-pions example cross-platform.
- [ ] Pions2Pions: Investigate ICE being unstable, not completing or even disconnecting. May be role assignment related.
- [ ] Pions2Pions: Investigate SCTP being unstable, seems to behave differently based on the timing of the SDP signaling.
- [x] DataChannels: Investigate ``Unhandled DataChannel message``.

Relates to #159