### PR TITLE
ICE: Implement keep-alive

### DIFF
--- a/pkg/ice/candidate.go
+++ b/pkg/ice/candidate.go
@@ -19,10 +19,19 @@ type Candidate interface {
 // CandidateBase represents an ICE candidate, a base with enough attributes
 // for host candidates, see CandidateSrflx and CandidateRelay for more
 type CandidateBase struct {
-	Protocol ProtoType
-	Address  string
-	Port     int
-	LastSeen time.Time
+	Protocol     ProtoType
+	Address      string
+	Port         int
+	LastSent     time.Time
+	LastReceived time.Time
+}
+
+func (c *CandidateBase) seen(outbound bool) {
+	if outbound {
+		c.LastSent = time.Now()
+	} else {
+		c.LastReceived = time.Now()
+	}
 }
 
 // Priority computes the priority for this ICE Candidate


### PR DESCRIPTION
- Periodically send a keep-alive Binding Indication.
- Downgrade connection state to disconnected after timeout.

Resolves #163 

Potential future improvements:
- Better connection management by pinging the candidate with binding requests (inspired by chrome implementation).
- Avoid keep-alive in case of data packets (gave up on this one due to callback/locking hell).
- Implement the Completed and Failed connection states.