### PR TITLE
Add examples of using pion-WebRTC with Janus

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you need commercial support or don't want to use public methods you can conta
 ### Related projects
 * [pions/turn](https://github.com/pions/turn): A simple extendable Golang TURN server
 * [WIP] [pions/media-server](https://github.com/pions/media-server): A Pion WebRTC powered media server, providing the building blocks for anything RTC.
-* [WIP] [pions/dcnet](https://github.com/pions/dcnet): A package providing Golang [net](https://godoc.org/net) interfaces around Pion WebRTC data channels. 
+* [WIP] [pions/dcnet](https://github.com/pions/dcnet): A package providing Golang [net](https://godoc.org/net) interfaces around Pion WebRTC data channels.
 
 ### Contributing
 Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contributing)** to join the group of amazing people making this project possible:
@@ -81,6 +81,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [wattanakorn495](https://github.com/wattanakorn495)
 * [Max Hawkins](https://github.com/maxhawkins) - *RTCP*
 * [Justin Okamoto](https://github.com/justinokamoto) - *Fix Docs*
+* [leeoxiang](https://github.com/notedit) - *Implement Janus examples*
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/examples/janus-gateway/README.md
+++ b/examples/janus-gateway/README.md
@@ -1,0 +1,23 @@
+# janus-gateway
+janus-gateway is a collection of examples showing how to use pion-WebRTC with [janus-gateway](https://github.com/meetecho/janus-gateway)
+
+These examples require that you build+enable websockets with Janus
+
+## streaming
+This example demonstrates how to download a video from a Janus streaming room. Before you run this example, you need to run `plugins/streams/test_gstreamer_1.sh` from Janus.
+
+You should confirm that you can successfully watch `Opus/VP8 live stream coming from gstreamer (live)` in the stream demo web UI
+
+### Running
+run `main.go` in `github.com/pions/webrtc/examples/janus-gateway/streaming`
+
+If this worked you will see the following.
+```
+Connection State has changed Checking
+Connection State has changed Connected
+Got VP8 track, saving to disk as output.ivf
+```
+Currently pion-WebRTC doesn't implement DTLS retransmissions so audio/video may not start successfully, and Janus will timeout with a DTLS error. Issue [#175](https://github.com/pions/webrtc/issues/175) is tracking this.
+If video does start in under 3 seconds stop and start the example again, this may take a few tries.
+
+If video did start successfully you will see output.ivf in the current folder.

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+
+	janus "github.com/notedit/janus-go"
+	"github.com/pions/webrtc"
+	"github.com/pions/webrtc/pkg/ice"
+	"github.com/pions/webrtc/pkg/media/ivfwriter"
+)
+
+func watchHandle(handle *janus.Handle) {
+	// wait for event
+	for {
+		msg := <-handle.Events
+		switch msg := msg.(type) {
+		case *janus.SlowLinkMsg:
+			fmt.Print("SlowLinkMsg type ", handle.Id)
+		case *janus.MediaMsg:
+			fmt.Print("MediaEvent type", msg.Type, " receiving ", msg.Receiving)
+		case *janus.WebRTCUpMsg:
+			fmt.Print("WebRTCUp type ", handle.Id)
+		case *janus.HangupMsg:
+			fmt.Print("HangupEvent type ", handle.Id)
+		case *janus.EventMsg:
+			fmt.Printf("EventMsg %+v", msg.Plugindata.Data)
+		}
+
+	}
+
+}
+
+func main() {
+	webrtc.RegisterDefaultCodecs()
+
+	// Create a new RTCPeerConnection
+	peerConnection, err := webrtc.New(webrtc.RTCConfiguration{})
+	if err != nil {
+		panic(err)
+	}
+
+	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+		fmt.Printf("Connection State has changed %s \n", connectionState.String())
+	}
+
+	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
+		if track.Codec.Name == webrtc.Opus {
+			return
+		}
+
+		fmt.Println("Got VP8 track, saving to disk as output.ivf")
+		i, err := ivfwriter.New("output.ivf")
+		if err != nil {
+			panic(err)
+		}
+		for {
+			if err := i.AddPacket(<-track.Packets); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	// Janus
+	gateway, err := janus.Connect("ws://localhost:8188/")
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Create session
+	session, err := gateway.Create()
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Create handle
+	handle, err := session.Attach("janus.plugin.streaming")
+
+	go watchHandle(handle)
+
+	// Get streaming list
+	if _, err := handle.Request(map[string]interface{}{
+		"request": "list",
+	}); err != nil {
+		panic(err)
+	}
+
+	// Watch the second stream
+	msg, err := handle.Message(map[string]interface{}{
+		"request": "watch",
+		"id":      1,
+	}, nil)
+
+	if err != nil {
+		fmt.Print("message", msg)
+		panic(err)
+	}
+
+	if msg.Jsep != nil {
+		if err := peerConnection.SetRemoteDescription(webrtc.RTCSessionDescription{
+			Type: webrtc.RTCSdpTypeOffer,
+			Sdp:  msg.Jsep["sdp"].(string),
+		}); err != nil {
+			panic(err)
+		}
+
+		answer, err := peerConnection.CreateAnswer(nil)
+		if err != nil {
+			panic(err)
+		}
+
+		// now we start
+		if _, err := handle.Message(map[string]interface{}{
+			"request": "start",
+		}, map[string]interface{}{
+			"type":    "answer",
+			"sdp":     answer.Sdp,
+			"trickle": false,
+		}); err != nil {
+			panic(err)
+		}
+	}
+	select {}
+}

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -771,6 +771,7 @@ func (pc *RTCPeerConnection) generateChannel(ssrc uint32, payloadType uint8) (bu
 	codec, err := pc.mediaEngine.getCodecSDP(sdpCodec)
 	if err != nil {
 		fmt.Printf("Codec %s in not registered\n", sdpCodec)
+		return nil
 	}
 
 	bufferTransport := make(chan *rtp.Packet, 15)


### PR DESCRIPTION
This adds an example of how to use pion-WebRTC with the streaming
plugin. This isn't production ready until #175 is resolved, but is
enough to start adding rough code/debugging around.

Resolves #74

Co-authored-by: Sean DuBois <sean@siobud.com>