### PR TITLE
Remove IceControlled Attr from ICE keepalive

### DIFF
--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -172,8 +172,6 @@ func (a *Agent) pingCandidate(local, remote Candidate) {
 func (a *Agent) keepaliveCandidate(local, remote Candidate) {
 	msg, err := stun.Build(stun.ClassIndication, stun.MethodBinding, stun.GenerateTransactionId(),
 		&stun.Username{Username: a.remoteUfrag + ":" + a.LocalUfrag},
-		&stun.IceControlled{TieBreaker: a.tieBreaker},
-		&stun.Priority{Priority: uint32(local.GetBase().Priority(HostCandidatePreference, 1))},
 		&stun.MessageIntegrity{
 			Key: []byte(a.remotePwd),
 		},


### PR DESCRIPTION
This value is incorrect if agent is controlling, instead of fixing
remove instead. We don't need this value in the keepalive.

Resolves #187