### PR TITLE
Fix RTCPeerConnection.Close segfault

### DIFF
--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -733,12 +733,12 @@ func (pc *RTCPeerConnection) SendRTCP(pkt rtcp.Packet) error {
 
 // Close ends the RTCPeerConnection
 func (pc *RTCPeerConnection) Close() error {
-	pc.networkManager.Close()
-
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #2)
 	if pc.isClosed {
 		return nil
 	}
+
+	pc.networkManager.Close()
 
 	// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close (step #3)
 	pc.isClosed = true


### PR DESCRIPTION
Multiple calls to RTCPeerConnection.Close would cause a segfault in
OpenSSL. Closing the NetworkManager was incorrectly placed after
the `isClosed` early return.

This moves the networkManager.Close() after that early return

Resolves #109