### PR TITLE
Adding Docker-compose for pion-to-pion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Max Hawkins](https://github.com/maxhawkins) - *RTCP*
 * [Justin Okamoto](https://github.com/justinokamoto) - *Fix Docs*
 * [leeoxiang](https://github.com/notedit) - *Implement Janus examples*
+* [Denis](https://github.com/Hixon10) - *Adding docker-compose to pion-to-pion example*
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/examples/pion-to-pion/README.md
+++ b/examples/pion-to-pion/README.md
@@ -17,3 +17,10 @@ offer
 ```
 
 You should see them connect and start to exchange messages.
+
+## You can use Docker-compose to start this example:
+```sh
+docker-compose up -d
+```
+
+Now, you can see message exchanging, using `docker logs`.

--- a/examples/pion-to-pion/answer/Dockerfile
+++ b/examples/pion-to-pion/answer/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.11
+
+COPY . /go/src/pion-to-pion/answer
+WORKDIR /go/src/pion-to-pion
+
+RUN apt-get update && apt-get install -y \
+  libssl-dev
+
+RUN go get -u github.com/pions/webrtc
+
+RUN go install -v ./...
+
+CMD ["answer"]
+
+EXPOSE 50000

--- a/examples/pion-to-pion/docker-compose.yml
+++ b/examples/pion-to-pion/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  answer:
+    container_name: answer
+    build: ./answer
+    hostname: answer
+    restart: always   
+    ports:
+      - 50000:50000
+    network_mode: "host"      
+      
+  offer:
+    depends_on:  
+      - answer
+    container_name: offer
+    build: ./offer
+    hostname: offer
+    restart: always
+    network_mode: "host"

--- a/examples/pion-to-pion/offer/Dockerfile
+++ b/examples/pion-to-pion/offer/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.11
+
+COPY . /go/src/pion-to-pion/offer
+WORKDIR /go/src/pion-to-pion
+
+RUN apt-get update && apt-get install -y \
+  libssl-dev
+
+RUN go get -u github.com/pions/webrtc
+
+RUN go install -v ./...
+
+CMD ["offer"]


### PR DESCRIPTION
Hello, 
I think, that docker-compose can help to start the example. If you don't like a docker, just Decline this PR.