### PR TITLE
GENERATE CERTIFICATE FINGERPRINT IN GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Justin Okamoto](https://github.com/justinokamoto) - *Fix Docs*
 * [leeoxiang](https://github.com/notedit) - *Implement Janus examples*
 * [Denis](https://github.com/Hixon10) - *Adding docker-compose to pion-to-pion example*
+* [earle](https://github.com/aguilEA) - *Generate DTLS fingerprint in Go*
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/internal/dtls/dtls.c
+++ b/internal/dtls/dtls.c
@@ -332,27 +332,7 @@ bool dtls_handle_outgoing(dtls_sess *sess, void *buf, int len, char *local, char
   return true;
 }
 
-char *dtls_tlscfg_fingerprint(tlscfg *cfg) {
-  if (cfg == NULL) {
-    return NULL;
-  }
 
-  unsigned int size;
-  unsigned char fingerprint[EVP_MAX_MD_SIZE];
-  if (X509_digest(cfg->cert, EVP_sha256(), (unsigned char *)fingerprint, &size) == 0) {
-    return NULL;
-  }
-
-  char *hex_fingeprint = calloc(1, sizeof(char) * 160);
-  char *curr = hex_fingeprint;
-  unsigned int i = 0;
-  for (i = 0; i < size; i++) {
-    sprintf(curr, "%.2X:", fingerprint[i]);
-    curr += 3;
-  }
-  *(curr - 1) = '\0';
-  return hex_fingeprint;
-}
 
 dtls_cert_pair *dtls_get_certpair(dtls_sess *sess) {
   if (sess->type == DTLS_CONTYPE_EXISTING) {

--- a/internal/dtls/dtls.go
+++ b/internal/dtls/dtls.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"sync"
 	"unsafe"
-
 	"github.com/pkg/errors"
 	"golang.org/x/net/ipv4"
 )
@@ -126,9 +125,23 @@ func (s *State) Close() {
 
 // Fingerprint generates a SHA-256 fingerprint of the certificate
 func (s *State) Fingerprint() string {
-	rawFingerprint := C.dtls_tlscfg_fingerprint(s.tlscfg)
-	defer C.free(unsafe.Pointer(rawFingerprint))
-	return C.GoString(rawFingerprint)
+	cfg := s.tlscfg
+	if cfg == nil{
+		return ""
+	}
+	var size uint
+	var fingerprint [C.EVP_MAX_MD_SIZE]byte
+	sizePtr := unsafe.Pointer(&size)
+	fingerprintPtr := unsafe.Pointer(&fingerprint)
+	if C.X509_digest(cfg.cert, C.EVP_sha256(), (*C.uchar)(fingerprintPtr), (*C.uint)(sizePtr)) == 0{
+		return ""
+	}
+	var hexFingerprint string
+	for i := uint(0); i < size; i++{
+		hexFingerprint += fmt.Sprintf("%.2X:", fingerprint[i])
+	}
+	hexFingerprint = hexFingerprint[:len(hexFingerprint)-1]
+	return hexFingerprint
 }
 
 // CertPair is the client+server key and profile extracted for SRTP
@@ -246,3 +259,4 @@ func RemoveListener(src string) {
 	delete(listenerMap, src)
 	listenerMapLock.Unlock()
 }
+

--- a/internal/dtls/dtls.h
+++ b/internal/dtls/dtls.h
@@ -65,7 +65,6 @@ dtls_decrypted *dtls_handle_incoming(dtls_sess *sess, void *buf, int len, char *
 bool dtls_handle_outgoing(dtls_sess *sess, void *buf, int len, char *local, char *remote);
 
 dtls_cert_pair *dtls_get_certpair(dtls_sess *sess);
-char *dtls_tlscfg_fingerprint(tlscfg *cfg);
 
 void dtls_session_cleanup(SSL_CTX *ssl_ctx, dtls_sess *dtls_session, tlscfg *cfg);
 


### PR DESCRIPTION
Implement dtls_tlscfg_fingerprint in Go.

Resolves #132