### PR TITLE
Allow Raw RTP input to RTCTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Denis](https://github.com/Hixon10) - *Adding docker-compose to pion-to-pion example*
 * [earle](https://github.com/aguilEA) - *Generate DTLS fingerprint in Go*
 * [Jake B](https://github.com/silbinarywolf) - *Fix Windows installation instructions*
+* [Michael MacDonald](https://github.com/mjmac)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/media.go
+++ b/media.go
@@ -20,4 +20,5 @@ type RTCTrack struct {
 	Codec       *RTCRtpCodec
 	Packets     <-chan *rtp.Packet
 	Samples     chan<- media.RTCSample
+	RawRTP      chan<- *rtp.Packet
 }

--- a/pkg/rtp/packetizer.go
+++ b/pkg/rtp/packetizer.go
@@ -43,6 +43,11 @@ func NewPacketizer(mtu int, pt uint8, ssrc uint32, payloader Payloader, sequence
 
 // Packetize packetizes the payload of an RTP packet and returns one or more RTP packets
 func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
+	// Guard against an empty payload
+	if len(payload) == 0 {
+		return nil
+	}
+
 	payloads := p.Payloader.Payload(p.MTU-12, payload)
 	packets := make([]*Packet, len(payloads))
 


### PR DESCRIPTION
Resolves #212

Support forwarding packets from existing RTP streams. Adds
the following new methods to RTCPeerConnection:
  * NewRawRTPTrack() -- expects a non-zero SSRC and accepts
    a stream of *rtp.Packet from an existing RTP stream
  * NewRTCSampleTrack() -- generates an SSRC and accepts
    a stream of media.RTCSample

Deprecates NewRTCTrack() in favor of NewRTCSampleTrack().

Exposes a new RawRTP channel on *RTCTrack instances which
accepts *rtp.Packet.