### PR TITLE
Run golang-ci against 1.9/1.11 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - "1.9"
-  - "master"
+  - "1.11"
 
 notifications:
   email: false


### PR DESCRIPTION
golang-ci is broken against master, golang-ci doesn't support master so
latest and (latest - 2) is good enough for now testing wise

Resolves #211