### PR TITLE
Safer Event Callbacks

### DIFF
--- a/examples/data-channels-create/main.go
+++ b/examples/data-channels-create/main.go
@@ -32,14 +32,12 @@ func main() {
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
-	}
-
-	dataChannel.Lock()
+	})
 
 	// Register channel opening handling
-	dataChannel.OnOpen = func() {
+	dataChannel.OnOpen(func() {
 		fmt.Printf("Data channel '%s'-'%d' open. Random messages will now be sent to any connected DataChannels every 5 seconds\n", dataChannel.Label, dataChannel.ID)
 		for {
 			time.Sleep(5 * time.Second)
@@ -49,10 +47,10 @@ func main() {
 			err := dataChannel.Send(datachannel.PayloadString{Data: []byte(message)})
 			util.Check(err)
 		}
-	}
+	})
 
-	// Register the Onmessage to handle incoming messages
-	dataChannel.Onmessage = func(payload datachannel.Payload) {
+	// Register the OnMessage to handle incoming messages
+	dataChannel.OnMessage(func(payload datachannel.Payload) {
 		switch p := payload.(type) {
 		case *datachannel.PayloadString:
 			fmt.Printf("Message '%s' from DataChannel '%s' payload '%s'\n", p.PayloadType().String(), dataChannel.Label, string(p.Data))
@@ -61,9 +59,7 @@ func main() {
 		default:
 			fmt.Printf("Message '%s' from DataChannel '%s' no payload \n", p.PayloadType().String(), dataChannel.Label)
 		}
-	}
-
-	dataChannel.Unlock()
+	})
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)

--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
 	// for the given codec
-	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack(func(track *webrtc.RTCTrack) {
 		codec := track.Codec
 		fmt.Printf("Track has started, of type %d: %s \n", track.PayloadType, codec.Name)
 		pipeline := gst.CreatePipeline(codec.Name)
@@ -40,13 +40,13 @@ func main() {
 			p := <-track.Packets
 			pipeline.Push(p.Raw)
 		}
-	}
+	})
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
-	}
+	})
 
 	// Wait for the offer to be pasted
 	sd := util.Decode(util.MustReadStdin())

--- a/examples/gstreamer-send-offer/main.go
+++ b/examples/gstreamer-send-offer/main.go
@@ -31,9 +31,9 @@ func main() {
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
-	}
+	})
 
 	// Create a audio track
 	opusTrack, err := peerConnection.NewRTCSampleTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -31,9 +31,9 @@ func main() {
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
-	}
+	})
 
 	// Create a audio track
 	opusTrack, err := peerConnection.NewRTCTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -52,11 +52,11 @@ func main() {
 	peerConnection, err := webrtc.New(config)
 	util.Check(err)
 
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
-	}
+	})
 
-	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack(func(track *webrtc.RTCTrack) {
 		if track.Codec.Name == webrtc.Opus {
 			return
 		}
@@ -68,7 +68,7 @@ func main() {
 			err = i.AddPacket(<-track.Packets)
 			util.Check(err)
 		}
-	}
+	})
 
 	// Janus
 	gateway, err := janus.Connect("ws://localhost:8188/")

--- a/examples/pion-to-pion/answer/main.go
+++ b/examples/pion-to-pion/answer/main.go
@@ -34,19 +34,16 @@ func main() {
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
-	}
+	})
 
 	// Register data channel creation handling
-	peerConnection.OnDataChannel = func(d *webrtc.RTCDataChannel) {
+	peerConnection.OnDataChannel(func(d *webrtc.RTCDataChannel) {
 		fmt.Printf("New DataChannel %s %d\n", d.Label, d.ID)
 
-		d.Lock()
-		defer d.Unlock()
-
 		// Register channel opening handling
-		d.OnOpen = func() {
+		d.OnOpen(func() {
 			fmt.Printf("Data channel '%s'-'%d' open. Random messages will now be sent to any connected DataChannels every 5 seconds\n", d.Label, d.ID)
 
 			for range time.NewTicker(5 * time.Second).C {
@@ -56,10 +53,10 @@ func main() {
 				err := d.Send(datachannel.PayloadString{Data: []byte(message)})
 				util.Check(err)
 			}
-		}
+		})
 
 		// Register message handling
-		d.Onmessage = func(payload datachannel.Payload) {
+		d.OnMessage(func(payload datachannel.Payload) {
 			switch p := payload.(type) {
 			case *datachannel.PayloadString:
 				fmt.Printf("Message '%s' from DataChannel '%s' payload '%s'\n", p.PayloadType().String(), d.Label, string(p.Data))
@@ -68,8 +65,8 @@ func main() {
 			default:
 				fmt.Printf("Message '%s' from DataChannel '%s' no payload \n", p.PayloadType().String(), d.Label)
 			}
-		}
-	}
+		})
+	})
 
 	// Exchange the offer/answer via HTTP
 	offerChan, answerChan := mustSignalViaHTTP(*addr)

--- a/examples/pion-to-pion/offer/main.go
+++ b/examples/pion-to-pion/offer/main.go
@@ -39,14 +39,12 @@ func main() {
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
-	}
-
-	dataChannel.Lock()
+	})
 
 	// Register channel opening handling
-	dataChannel.OnOpen = func() {
+	dataChannel.OnOpen(func() {
 		fmt.Printf("Data channel '%s'-'%d' open. Random messages will now be sent to any connected DataChannels every 5 seconds\n", dataChannel.Label, dataChannel.ID)
 
 		for range time.NewTicker(5 * time.Second).C {
@@ -56,10 +54,10 @@ func main() {
 			err := dataChannel.Send(datachannel.PayloadString{Data: []byte(message)})
 			util.Check(err)
 		}
-	}
+	})
 
-	// Register the Onmessage to handle incoming messages
-	dataChannel.Onmessage = func(payload datachannel.Payload) {
+	// Register the OnMessage to handle incoming messages
+	dataChannel.OnMessage(func(payload datachannel.Payload) {
 		switch p := payload.(type) {
 		case *datachannel.PayloadString:
 			fmt.Printf("Message '%s' from DataChannel '%s' payload '%s'\n", p.PayloadType().String(), dataChannel.Label, string(p.Data))
@@ -68,9 +66,7 @@ func main() {
 		default:
 			fmt.Printf("Message '%s' from DataChannel '%s' no payload \n", p.PayloadType().String(), dataChannel.Label)
 		}
-	}
-
-	dataChannel.Unlock()
+	})
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -33,7 +33,7 @@ func main() {
 	// Set a handler for when a new remote track starts, this handler saves buffers to disk as
 	// an ivf file, since we could have multiple video tracks we provide a counter.
 	// In your application this is where you would handle/process video
-	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack(func(track *webrtc.RTCTrack) {
 		if track.Codec.Name == webrtc.VP8 {
 			fmt.Println("Got VP8 track, saving to disk as output.ivf")
 			i, err := ivfwriter.New("output.ivf")
@@ -43,13 +43,13 @@ func main() {
 				util.Check(err)
 			}
 		}
-	}
+	})
 
 	// Set the handler for ICE connection state
 	// This will notify you when the peer has connected/disconnected
-	peerConnection.OnICEConnectionStateChange = func(connectionState ice.ConnectionState) {
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
-	}
+	})
 
 	// Wait for the offer to be pasted
 	sd := util.Decode(util.MustReadStdin())

--- a/examples/sfu/main.go
+++ b/examples/sfu/main.go
@@ -63,7 +63,7 @@ func main() {
 	var outboundSamplesLock sync.RWMutex
 	// Set a handler for when a new remote track starts, this just distributes all our packets
 	// to connected peers
-	peerConnection.OnTrack = func(track *webrtc.RTCTrack) {
+	peerConnection.OnTrack(func(track *webrtc.RTCTrack) {
 		// Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
 		// This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
 		go func() {
@@ -91,7 +91,7 @@ func main() {
 			}
 			outboundSamplesLock.RUnlock()
 		}
-	}
+	})
 
 	// Set the remote SessionDescription
 	check(peerConnection.SetRemoteDescription(webrtc.RTCSessionDescription{

--- a/media.go
+++ b/media.go
@@ -5,11 +5,6 @@ import (
 	"github.com/pions/webrtc/pkg/rtp"
 )
 
-// RTCSample contains media, and the amount of samples in it
-//
-// Deprecated: use RTCSample from github.com/pions/webrtc/pkg/media instead
-type RTCSample = media.RTCSample
-
 // RTCTrack represents a track that is communicated
 type RTCTrack struct {
 	ID          string

--- a/rtcdatachannel_test.go
+++ b/rtcdatachannel_test.go
@@ -1,7 +1,14 @@
 package webrtc
 
 import (
+	"crypto/rand"
+	"encoding/binary"
+	"math/big"
 	"testing"
+	"time"
+
+	"github.com/pions/webrtc/pkg/datachannel"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateDataChannelID(t *testing.T) {
@@ -32,4 +39,100 @@ func TestGenerateDataChannelID(t *testing.T) {
 			t.Errorf("Wrong id: %d expected %d", id, testCase.result)
 		}
 	}
+}
+
+func TestRTCDataChannel_EventHandlers(t *testing.T) {
+	dc := &RTCDataChannel{}
+
+	onOpenCalled := make(chan bool)
+	onMessageCalled := make(chan bool)
+
+	// Verify that the noop case works
+	assert.NotPanics(t, func() { dc.onOpen() })
+	assert.NotPanics(t, func() { dc.onMessage(nil) })
+
+	dc.OnOpen(func() {
+		onOpenCalled <- true
+	})
+
+	dc.OnMessage(func(p datachannel.Payload) {
+		go func() {
+			onMessageCalled <- true
+		}()
+	})
+
+	// Verify that the handlers deal with nil inputs
+	assert.NotPanics(t, func() { dc.onMessage(nil) })
+
+	// Verify that the set handlers are called
+	assert.NotPanics(t, func() { dc.onOpen() })
+	assert.NotPanics(t, func() { dc.onMessage(&datachannel.PayloadString{Data: []byte("o hai")}) })
+
+	allTrue := func(vals []bool) bool {
+		for _, val := range vals {
+			if !val {
+				return false
+			}
+		}
+		return true
+	}
+
+	assert.True(t, allTrue([]bool{
+		<-onOpenCalled,
+		<-onMessageCalled,
+	}))
+}
+
+func TestRTCDataChannel_MessagesAreOrdered(t *testing.T) {
+	dc := &RTCDataChannel{}
+
+	max := 512
+	out := make(chan int)
+	inner := func(p datachannel.Payload) {
+		// randomly sleep
+		// NB: The big.Int/crypto.Rand is overkill but makes the linter happy
+		randInt, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+		if err != nil {
+			t.Fatalf("Failed to get random sleep duration: %s", err)
+		}
+		time.Sleep(time.Duration(randInt.Int64()) * time.Microsecond)
+		switch p := p.(type) {
+		case *datachannel.PayloadBinary:
+			s, _ := binary.Varint(p.Data)
+			out <- int(s)
+		}
+	}
+	dc.OnMessage(func(p datachannel.Payload) {
+		inner(p)
+	})
+
+	go func() {
+		for i := 1; i <= max; i++ {
+			buf := make([]byte, 8)
+			binary.PutVarint(buf, int64(i))
+			dc.onMessage(&datachannel.PayloadBinary{Data: buf})
+			// Change the registered handler a couple of times to make sure
+			// that everything continues to work, we don't lose messages, etc.
+			if i%2 == 0 {
+				hdlr := func(p datachannel.Payload) {
+					inner(p)
+				}
+				dc.OnMessage(hdlr)
+			}
+		}
+	}()
+
+	values := make([]int, 0, max)
+	for v := range out {
+		values = append(values, v)
+		if len(values) == max {
+			close(out)
+		}
+	}
+
+	expected := make([]int, max)
+	for i := 1; i <= max; i++ {
+		expected[i-1] = i
+	}
+	assert.EqualValues(t, expected, values)
 }


### PR DESCRIPTION
Resolves #218

Change Event Callback APIs to setter functions which take care of
locking so that users don't need to know about or remember
to do this.