### PR TITLE
Use the latest releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.9.x"
-  - "1.11.x"
+  - "1.x" # use the latest Go release
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.9"
-  - "1.11"
+  - "1.9.x"
+  - "1.11.x"
 
 notifications:
   email: false


### PR DESCRIPTION
Should we also run on `1.10.x`?