### PR TITLE
Update examples to use non-deprecated APIs

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -15,7 +15,7 @@ import (
 // Examples represents the examples loaded from examples.json.
 type Examples []Example
 
-// Examples represents an example loaded from examples.json.
+// Example represents an example loaded from examples.json.
 type Example struct {
 	Title       string `json:"title"`
 	Link        string `json:"link"`
@@ -83,10 +83,10 @@ func serve(addr string) error {
 // getExamples loads the examples from the examples.json file.
 func getExamples() (*Examples, error) {
 	file, err := os.Open("./examples.json")
-	defer file.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list examples (please run in the examples folder): %v", err)
 	}
+	defer file.Close()
 
 	var examples Examples
 	err = json.NewDecoder(file).Decode(&examples)

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -36,13 +36,13 @@ func main() {
 	})
 
 	// Create a audio track
-	opusTrack, err := peerConnection.NewRTCTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")
+	opusTrack, err := peerConnection.NewRTCSampleTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")
 	util.Check(err)
 	_, err = peerConnection.AddTrack(opusTrack)
 	util.Check(err)
 
 	// Create a video track
-	vp8Track, err := peerConnection.NewRTCTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
+	vp8Track, err := peerConnection.NewRTCSampleTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
 	util.Check(err)
 	_, err = peerConnection.AddTrack(vp8Track)
 	util.Check(err)

--- a/examples/sfu/main.go
+++ b/examples/sfu/main.go
@@ -68,13 +68,9 @@ func main() {
 		// This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
 		go func() {
 			ticker := time.NewTicker(rtcpPLIInterval)
-			for {
-				select {
-				case <-ticker.C:
-					err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.Ssrc})
-					if err != nil {
-						fmt.Println(err)
-					}
+			for range ticker.C {
+				if err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.Ssrc}); err != nil {
+					fmt.Println(err)
 				}
 			}
 		}()
@@ -116,7 +112,7 @@ func main() {
 		check(err)
 
 		// Create a single VP8 Track to send videa
-		vp8Track, err := peerConnection.NewRTCTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
+		vp8Track, err := peerConnection.NewRTCSampleTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
 		check(err)
 
 		_, err = peerConnection.AddTrack(vp8Track)


### PR DESCRIPTION
Move from NewRTCTrack -> NewRTCSampleTrack and a few other
simple cases

Resolves #238