### PR TITLE
Fix multi-package coverage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor/
 #############
 *.ivf
 tags
+.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,16 @@ before_install:
 
 before_script:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.10.2
-  - go get github.com/mattn/goveralls
+  - go get github.com/mattn/goveralls github.com/modocache/gover
 
 script:
   - bash .github/build-examples.sh
   - rm -rf examples
   # Remove examples, no test coverage for them
   - golangci-lint run
-  - goveralls -v -race -covermode=atomic -service=travis-ci
+  - go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs sh -c
+  - gover
+  - goveralls -v -race -coverprofile=gover.coverprofile -service=travis-ci
   - bash .github/assert-contributors.sh
   - bash .github/lint-disallowed-functions-in-library.sh
   - bash .github/lint-commit-message.sh


### PR DESCRIPTION
We are currently only uploading the coverage for the main package, so
our coverage appears much lower then it really is. This updates our
tooling to properly cover every package

Resolves #240