### PR TITLE
RTCP API Changes

### DIFF
--- a/internal/network/port-receive.go
+++ b/internal/network/port-receive.go
@@ -24,17 +24,10 @@ func handleRTCP(getBufferTransports func(uint32) *TransportPair, buffer []byte) 
 	//decrypted packets can also be compound packets, so we have to nest our reader loop here.
 	compoundPacket := rtcp.NewReader(bytes.NewReader(buffer))
 	for {
-		_, rawrtcp, err := compoundPacket.ReadPacket()
-
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			fmt.Println(err)
-			return
+		packet, err := compoundPacket.ReadPacket()
+		if err == io.EOF {
+			break
 		}
-
-		packet, _, err := rtcp.Unmarshal(rawrtcp)
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/internal/network/port_test.go
+++ b/internal/network/port_test.go
@@ -1,115 +1,138 @@
 package network
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/pions/webrtc/pkg/rtcp"
-	"github.com/stretchr/testify/assert"
 )
 
-// An RTCP packet from a packet dump
-var realPacket = []byte{
-	// Receiver Report (offset=0)
-	// v=2, p=0, count=1, RR, len=7
-	0x81, 0xc9, 0x0, 0x7,
-	// ssrc=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
-	// ssrc=0xbc5e9a40
-	0xbc, 0x5e, 0x9a, 0x40,
-	// fracLost=0, totalLost=0
-	0x0, 0x0, 0x0, 0x0,
-	// lastSeq=0x46e1
-	0x0, 0x0, 0x46, 0xe1,
-	// jitter=273
-	0x0, 0x0, 0x1, 0x11,
-	// lsr=0x9f36432
-	0x9, 0xf3, 0x64, 0x32,
-	// delay=150137
-	0x0, 0x2, 0x4a, 0x79,
+func TestHandleRTCP(t *testing.T) {
+	for _, test := range []struct {
+		Name      string
+		RawPacket []byte
+		WantTypes []rtcp.PacketType
+	}{
+		{
+			// An RTCP packet from a packet dump
+			Name: "Real RR",
+			RawPacket: []byte{
+				// Receiver Report (offset=0)
+				// v=2, p=0, count=1, RR, len=7
+				0x81, 0xc9, 0x0, 0x7,
+				// ssrc=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// ssrc=0xbc5e9a40
+				0xbc, 0x5e, 0x9a, 0x40,
+				// fracLost=0, totalLost=0
+				0x0, 0x0, 0x0, 0x0,
+				// lastSeq=0x46e1
+				0x0, 0x0, 0x46, 0xe1,
+				// jitter=273
+				0x0, 0x0, 0x1, 0x11,
+				// lsr=0x9f36432
+				0x9, 0xf3, 0x64, 0x32,
+				// delay=150137
+				0x0, 0x2, 0x4a, 0x79,
 
-	// Source Description (offset=32)
-	// v=2, p=0, count=1, SDES, len=12
-	0x81, 0xca, 0x0, 0xc,
-	// ssrc=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
-	// CNAME, len=38
-	0x1, 0x26,
-	// text="{9c00eb92-1afb-9d49-a47d-91f64eee69f5}"
-	0x7b, 0x39, 0x63, 0x30,
-	0x30, 0x65, 0x62, 0x39,
-	0x32, 0x2d, 0x31, 0x61,
-	0x66, 0x62, 0x2d, 0x39,
-	0x64, 0x34, 0x39, 0x2d,
-	0x61, 0x34, 0x37, 0x64,
-	0x2d, 0x39, 0x31, 0x66,
-	0x36, 0x34, 0x65, 0x65,
-	0x65, 0x36, 0x39, 0x66,
-	0x35, 0x7d,
-	// END + padding
-	0x0, 0x0, 0x0, 0x0,
+				// Source Description (offset=32)
+				// v=2, p=0, count=1, SDES, len=12
+				0x81, 0xca, 0x0, 0xc,
+				// ssrc=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// CNAME, len=38
+				0x1, 0x26,
+				// text="{9c00eb92-1afb-9d49-a47d-91f64eee69f5}"
+				0x7b, 0x39, 0x63, 0x30,
+				0x30, 0x65, 0x62, 0x39,
+				0x32, 0x2d, 0x31, 0x61,
+				0x66, 0x62, 0x2d, 0x39,
+				0x64, 0x34, 0x39, 0x2d,
+				0x61, 0x34, 0x37, 0x64,
+				0x2d, 0x39, 0x31, 0x66,
+				0x36, 0x34, 0x65, 0x65,
+				0x65, 0x36, 0x39, 0x66,
+				0x35, 0x7d,
+				// END + padding
+				0x0, 0x0, 0x0, 0x0,
 
-	// Goodbye (offset=84)
-	// v=2, p=0, count=1, BYE, len=1
-	0x81, 0xcb, 0x0, 0x1,
-	// source=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
+				// Goodbye (offset=84)
+				// v=2, p=0, count=1, BYE, len=1
+				0x81, 0xcb, 0x0, 0x1,
+				// source=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
 
-	// Picture Loss Indication (offset=92)
-	0x81, 0xce, 0x0, 0x2,
-	// sender=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
-	// media=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
+				// Picture Loss Indication (offset=92)
+				0x81, 0xce, 0x0, 0x2,
+				// sender=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// media=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
 
-	// RapidResynchronizationRequest (offset=104)
-	0x85, 0xcd, 0x0, 0x2,
-	// sender=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
-	// media=0x902f9e2e
-	0x90, 0x2f, 0x9e, 0x2e,
-}
+				// RapidResynchronizationRequest (offset=104)
+				0x85, 0xcd, 0x0, 0x2,
+				// sender=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// media=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+			},
+			WantTypes: []rtcp.PacketType{
+				rtcp.TypeReceiverReport,
+				rtcp.TypeSourceDescription,
+				rtcp.TypeGoodbye,
+				rtcp.TypePayloadSpecificFeedback,
+				rtcp.TypeTransportSpecificFeedback,
+			},
+		},
+		{
+			Name: "sender report",
+			RawPacket: []byte{
+				// v=2, p=0, count=1, SR, len=12
+				0x81, 0xc8, 0x00, 0x0c,
+				// ssrc=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// ntp=0xda8bd1fcdddda05a
+				0xda, 0x8b, 0xd1, 0xfc,
+				0xdd, 0xdd, 0xa0, 0x5a,
+				// rtp=0xaaf4edd5
+				0xaa, 0xf4, 0xed, 0xd5,
+				// packetCount=1
+				0x00, 0x00, 0x00, 0x01,
+				// octetCount=2
+				0x00, 0x00, 0x00, 0x02,
+				// ssrc=0xbc5e9a40
+				0xbc, 0x5e, 0x9a, 0x40,
+				// fracLost=0, totalLost=0
+				0x0, 0x0, 0x0, 0x0,
+				// lastSeq=0x46e1
+				0x0, 0x0, 0x46, 0xe1,
+				// jitter=273
+				0x0, 0x0, 0x1, 0x11,
+				// lsr=0x9f36432
+				0x9, 0xf3, 0x64, 0x32,
+				// delay=150137
+				0x0, 0x2, 0x4a, 0x79,
+			},
+			WantTypes: []rtcp.PacketType{
+				rtcp.TypeSenderReport,
+			},
+		},
+	} {
+		pktChannel := make(chan rtcp.Packet, 6)
+		getBufStub := func(uint32) *TransportPair {
+			return &TransportPair{nil, pktChannel}
+		}
 
-func TestHandleRtcp(t *testing.T) {
-	pktChannel := make(chan rtcp.Packet, 6)
-	getBufStub := func(uint32) *TransportPair {
-		return &TransportPair{nil, pktChannel}
-	}
+		handleRTCP(getBufStub, test.RawPacket)
+		close(pktChannel)
 
-	handleRTCP(getBufStub, realPacket)
+		var gotTypes []rtcp.PacketType
+		for pkt := range pktChannel {
+			gotTypes = append(gotTypes, pkt.Header().Type)
+		}
 
-	select {
-	case parsed := <-pktChannel:
-		assert.IsType(t, parsed, (*rtcp.ReceiverReport)(nil), "Unmarshalled to incorrect type")
-	default:
-		t.Fatalf("Not enough packets parsed from channel")
-	}
-	select {
-	case parsed := <-pktChannel:
-		assert.IsType(t, parsed, (*rtcp.SourceDescription)(nil), "Unmarshalled to incorrect type")
-	default:
-		t.Fatalf("Not enough packets parsed from channel")
-	}
-	select {
-	case parsed := <-pktChannel:
-		assert.IsType(t, parsed, (*rtcp.Goodbye)(nil), "Unmarshalled to incorrect type")
-	default:
-		t.Fatalf("Not enough packets parsed from channel")
-	}
-	select {
-	case parsed := <-pktChannel:
-		assert.IsType(t, parsed, (*rtcp.PictureLossIndication)(nil), "Unmarshalled to incorrect type")
-	default:
-		t.Fatalf("Not enough packets parsed from channel")
-	}
-	select {
-	case parsed := <-pktChannel:
-		assert.IsType(t, parsed, (*rtcp.RapidResynchronizationRequest)(nil), "Unmarshalled to incorrect type")
-	default:
-		t.Fatalf("Not enough packets parsed from channel")
-	}
-	select {
-	case <-pktChannel:
-		t.Fatalf("Too many packets parsed from channel")
-	default:
+		if !reflect.DeepEqual(gotTypes, test.WantTypes) {
+			t.Fatalf("Got packet types %v, want %v", gotTypes, test.WantTypes)
+		}
 	}
 }

--- a/pkg/rtcp/packet.go
+++ b/pkg/rtcp/packet.go
@@ -2,6 +2,8 @@ package rtcp
 
 // Packet represents an RTCP packet, a protocol used for out-of-band statistics and control information for an RTP session
 type Packet interface {
+	Header() Header
+
 	Marshal() ([]byte, error)
 	Unmarshal(rawPacket []byte) error
 }

--- a/pkg/rtcp/packet.go
+++ b/pkg/rtcp/packet.go
@@ -36,10 +36,9 @@ func Unmarshal(rawPacket []byte) (Packet, Header, error) {
 		p = new(PictureLossIndication)
 
 	default:
-		return nil, h, errWrongType
+		p = new(RawPacket)
 	}
 
 	err = p.Unmarshal(rawPacket)
 	return p, h, err
-
 }

--- a/pkg/rtcp/packet.go
+++ b/pkg/rtcp/packet.go
@@ -8,14 +8,18 @@ type Packet interface {
 	Unmarshal(rawPacket []byte) error
 }
 
-// Unmarshal is a factory a polymorphic RTCP packet, and its header,
-func Unmarshal(rawPacket []byte) (Packet, Header, error) {
+// Unmarshal parses a raw RTCP byte array and returns a Packet.
+//
+// If the packet has an implemented type you can use a type assertion
+// to access the fields of the packet. If the packet's type is unknown
+// then a RawPacket will be returned instead.
+func Unmarshal(rawPacket []byte) (Packet, error) {
 	var h Header
 	var p Packet
 
 	err := h.Unmarshal(rawPacket)
 	if err != nil {
-		return nil, h, err
+		return nil, err
 	}
 
 	switch h.Type {
@@ -42,5 +46,5 @@ func Unmarshal(rawPacket []byte) (Packet, Header, error) {
 	}
 
 	err = p.Unmarshal(rawPacket)
-	return p, h, err
+	return p, err
 }

--- a/pkg/rtcp/packet_test.go
+++ b/pkg/rtcp/packet_test.go
@@ -1,0 +1,28 @@
+package rtcp
+
+import (
+	"fmt"
+)
+
+func ExampleUnmarshal() {
+	data := []byte{
+		// RapidResynchronizationRequest
+		0x85, 0xcd, 0x0, 0x2,
+		// sender=0x902f9e2e
+		0x90, 0x2f, 0x9e, 0x2e,
+		// media=0x902f9e2e
+		0x90, 0x2f, 0x9e, 0x2e,
+	}
+	packet, err := Unmarshal(data)
+	if err != nil {
+		panic(err)
+	}
+
+	switch p := packet.(type) {
+	case *RapidResynchronizationRequest:
+		fmt.Println(p.MediaSSRC)
+	case *RawPacket:
+		fmt.Printf("unknown packet type: %d\n", p.Header().Type)
+	}
+	// Output: 2419039790
+}

--- a/pkg/rtcp/picture_loss_indication.go
+++ b/pkg/rtcp/picture_loss_indication.go
@@ -26,21 +26,19 @@ func (p PictureLossIndication) Marshal() ([]byte, error) {
 	 *
 	 * The semantics of this FB message is independent of the payload type.
 	 */
-	rawPacket := make([]byte, 8)
-	binary.BigEndian.PutUint32(rawPacket, p.SenderSSRC)
-	binary.BigEndian.PutUint32(rawPacket[4:], p.MediaSSRC)
+	rawPacket := make([]byte, p.len())
+	packetBody := rawPacket[headerLength:]
 
-	h := Header{
-		Count:  pliFMT,
-		Type:   TypePayloadSpecificFeedback,
-		Length: pliLength,
-	}
-	hData, err := h.Marshal()
+	binary.BigEndian.PutUint32(packetBody, p.SenderSSRC)
+	binary.BigEndian.PutUint32(packetBody[4:], p.MediaSSRC)
+
+	hData, err := p.Header().Marshal()
 	if err != nil {
 		return nil, err
 	}
+	copy(rawPacket, hData)
 
-	return append(hData, rawPacket...), nil
+	return rawPacket, nil
 }
 
 // Unmarshal decodes the PictureLossIndication from binary
@@ -61,4 +59,17 @@ func (p *PictureLossIndication) Unmarshal(rawPacket []byte) error {
 	p.SenderSSRC = binary.BigEndian.Uint32(rawPacket[headerLength:])
 	p.MediaSSRC = binary.BigEndian.Uint32(rawPacket[headerLength+ssrcLength:])
 	return nil
+}
+
+// Header returns the Header associated with this packet.
+func (p *PictureLossIndication) Header() Header {
+	return Header{
+		Count:  pliFMT,
+		Type:   TypePayloadSpecificFeedback,
+		Length: pliLength,
+	}
+}
+
+func (p *PictureLossIndication) len() int {
+	return headerLength + ssrcLength*2
 }

--- a/pkg/rtcp/raw_packet.go
+++ b/pkg/rtcp/raw_packet.go
@@ -1,0 +1,25 @@
+package rtcp
+
+// RawPacket represents an unparsed RTCP packet. It's returned by Unmarshal when
+// a packet with an unknown type is encountered.
+type RawPacket []byte
+
+// Marshal encodes the packet in binary.
+func (r RawPacket) Marshal() ([]byte, error) {
+	return r, nil
+}
+
+// Unmarshal decodes the packet from binary.
+func (r *RawPacket) Unmarshal(b []byte) error {
+	if len(b) < (headerLength) {
+		return errPacketTooShort
+	}
+	*r = b
+
+	var h Header
+	if err := h.Unmarshal(b); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/rtcp/raw_packet.go
+++ b/pkg/rtcp/raw_packet.go
@@ -23,3 +23,12 @@ func (r *RawPacket) Unmarshal(b []byte) error {
 
 	return nil
 }
+
+// Header returns the Header associated with this packet.
+func (r RawPacket) Header() Header {
+	var h Header
+	if err := h.Unmarshal(r); err != nil {
+		return Header{}
+	}
+	return h
+}

--- a/pkg/rtcp/raw_packet_test.go
+++ b/pkg/rtcp/raw_packet_test.go
@@ -1,0 +1,61 @@
+package rtcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRawPacketRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		Name               string
+		Packet             RawPacket
+		WantMarshalError   error
+		WantUnmarshalError error
+	}{
+		{
+			Name: "valid",
+			Packet: RawPacket([]byte{
+				// v=2, p=0, count=1, BYE, len=12
+				0x81, 0xcb, 0x00, 0x0c,
+				// ssrc=0x902f9e2e
+				0x90, 0x2f, 0x9e, 0x2e,
+				// len=3, text=FOO
+				0x03, 0x46, 0x4f, 0x4f,
+			}),
+		},
+		{
+			Name:               "short header",
+			Packet:             RawPacket([]byte{0x00}),
+			WantUnmarshalError: errPacketTooShort,
+		},
+		{
+			Name: "invalid header",
+			Packet: RawPacket([]byte{
+				// v=0, p=0, count=0, RR, len=4
+				0x00, 0xc9, 0x00, 0x04,
+			}),
+			WantUnmarshalError: errBadVersion,
+		},
+	} {
+		data, err := test.Packet.Marshal()
+		if got, want := err, test.WantMarshalError; got != want {
+			t.Fatalf("Marshal %q: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		var decoded RawPacket
+		err = decoded.Unmarshal(data)
+		if got, want := err, test.WantUnmarshalError; got != want {
+			t.Fatalf("Unmarshal %q: err = %v, want %v", test.Name, got, want)
+		}
+		if err != nil {
+			continue
+		}
+
+		if got, want := decoded, test.Packet; !reflect.DeepEqual(got, want) {
+			t.Fatalf("%q raw round trip: got %#v, want %#v", test.Name, got, want)
+		}
+	}
+}

--- a/pkg/rtcp/reader_test.go
+++ b/pkg/rtcp/reader_test.go
@@ -75,15 +75,11 @@ func TestUnmarshal(t *testing.T) {
 	r := NewReader(bytes.NewReader(realPacket))
 
 	// ReceiverReport
-	_, packet, err := r.ReadPacket()
+	packet, err := r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read rr: %v", err)
 	}
-	var parsed Packet
-	if parsed, _, err = Unmarshal(packet); err != nil {
-		t.Errorf("Unmarshal parsed: %v", err)
-	}
-	assert.IsType(t, parsed, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
+	assert.IsType(t, packet, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
 
 	wantRR := &ReceiverReport{
 		SSRC: 0x902f9e2e,
@@ -97,20 +93,17 @@ func TestUnmarshal(t *testing.T) {
 			Delay:              150137,
 		}},
 	}
-	if got, want := wantRR, parsed; !reflect.DeepEqual(got, want) {
+	if got, want := wantRR, packet; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal rr: got %#v, want %#v", got, want)
 	}
 
 	// SourceDescription
-	_, packet, err = r.ReadPacket()
+	packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read sdes: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
-		t.Errorf("Unmarshal parsed: %v", err)
-	}
-	assert.IsType(t, parsed, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
+	assert.IsType(t, packet, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
 
 	wantSdes := &SourceDescription{
 		Chunks: []SourceDescriptionChunk{
@@ -126,66 +119,54 @@ func TestUnmarshal(t *testing.T) {
 		},
 	}
 
-	if got, want := parsed, wantSdes; !reflect.DeepEqual(got, want) {
+	if got, want := packet, wantSdes; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal sdes: got %#v, want %#v", got, want)
 	}
 
 	// Goodbye
-	_, packet, err = r.ReadPacket()
+	packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read bye: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
-		t.Errorf("Unmarshal parsed: %v", err)
-	}
-
-	assert.IsType(t, parsed, (*Goodbye)(nil), "Unmarshalled to incorrect type")
+	assert.IsType(t, packet, (*Goodbye)(nil), "Unmarshalled to incorrect type")
 
 	wantBye := &Goodbye{
 		Sources: []uint32{0x902f9e2e},
 	}
-	if got, want := parsed, wantBye; !reflect.DeepEqual(got, want) {
+	if got, want := packet, wantBye; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal bye: got %#v, want %#v", got, want)
 	}
 
 	// PictureLossIndication
-	_, packet, err = r.ReadPacket()
+	packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read pli: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
-		t.Errorf("Unmarshal parsed: %v", err)
-	}
-
-	assert.IsType(t, parsed, (*PictureLossIndication)(nil), "Unmarshalled to incorrect type")
+	assert.IsType(t, packet, (*PictureLossIndication)(nil), "Unmarshalled to incorrect type")
 
 	wantPli := &PictureLossIndication{
 		SenderSSRC: 0x902f9e2e,
 		MediaSSRC:  0x902f9e2e,
 	}
-	if got, want := parsed, wantPli; !reflect.DeepEqual(got, want) {
+	if got, want := packet, wantPli; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal pli: got %#v, want %#v", got, want)
 	}
 
 	// RapidResynchronizationRequest
-	_, packet, err = r.ReadPacket()
+	packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read rrr: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
-		t.Errorf("Unmarshal parsed: %v", err)
-	}
-
-	assert.IsType(t, parsed, (*RapidResynchronizationRequest)(nil), "Unmarshalled to incorrect type")
+	assert.IsType(t, packet, (*RapidResynchronizationRequest)(nil), "Unmarshalled to incorrect type")
 
 	wantRrr := &RapidResynchronizationRequest{
 		SenderSSRC: 0x902f9e2e,
 		MediaSSRC:  0x902f9e2e,
 	}
-	if got, want := parsed, wantRrr; !reflect.DeepEqual(got, want) {
+	if got, want := packet, wantRrr; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal rrr: got %#v, want %#v", got, want)
 	}
 }
@@ -196,7 +177,7 @@ func TestReadEOF(t *testing.T) {
 	}
 
 	r := NewReader(bytes.NewReader(shortHeader))
-	_, _, err := r.ReadPacket()
+	_, err := r.ReadPacket()
 	if got, want := err, io.ErrUnexpectedEOF; got != want {
 		t.Fatalf("read short header: got err = %v, want %v", got, want)
 	}

--- a/pkg/rtcp/reception_report.go
+++ b/pkg/rtcp/reception_report.go
@@ -124,3 +124,7 @@ func (r *ReceptionReport) Unmarshal(rawPacket []byte) error {
 
 	return nil
 }
+
+func (r *ReceptionReport) len() int {
+	return receptionReportLength
+}

--- a/pkg/rtcp/sender_report.go
+++ b/pkg/rtcp/sender_report.go
@@ -87,37 +87,33 @@ func (r SenderReport) Marshal() ([]byte, error) {
 	 *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	 */
 
-	rawPacket := make([]byte, srHeaderLength)
+	rawPacket := make([]byte, r.len())
+	packetBody := rawPacket[headerLength:]
 
-	binary.BigEndian.PutUint32(rawPacket[srSSRCOffset:], r.SSRC)
-	binary.BigEndian.PutUint64(rawPacket[srNTPOffset:], r.NTPTime)
-	binary.BigEndian.PutUint32(rawPacket[srRTPOffset:], r.RTPTime)
-	binary.BigEndian.PutUint32(rawPacket[srPacketCountOffset:], r.PacketCount)
-	binary.BigEndian.PutUint32(rawPacket[srOctetCountOffset:], r.OctetCount)
+	binary.BigEndian.PutUint32(packetBody[srSSRCOffset:], r.SSRC)
+	binary.BigEndian.PutUint64(packetBody[srNTPOffset:], r.NTPTime)
+	binary.BigEndian.PutUint32(packetBody[srRTPOffset:], r.RTPTime)
+	binary.BigEndian.PutUint32(packetBody[srPacketCountOffset:], r.PacketCount)
+	binary.BigEndian.PutUint32(packetBody[srOctetCountOffset:], r.OctetCount)
 
-	for _, rp := range r.Reports {
+	for i, rp := range r.Reports {
 		data, err := rp.Marshal()
 		if err != nil {
 			return nil, err
 		}
-		rawPacket = append(rawPacket, data...)
+		offset := srHeaderLength + receptionReportLength*i
+		copy(packetBody[offset:], data)
 	}
 
 	if len(r.Reports) > countMax {
 		return nil, errTooManyReports
 	}
 
-	h := Header{
-		Count:  uint8(len(r.Reports)),
-		Type:   TypeSenderReport,
-		Length: uint16(((headerLength + len(rawPacket)) / 4) - 1),
-	}
-	hData, err := h.Marshal()
+	hData, err := r.Header().Marshal()
 	if err != nil {
 		return nil, err
 	}
-
-	rawPacket = append(hData, rawPacket...)
+	copy(rawPacket, hData)
 
 	return rawPacket, nil
 }
@@ -196,4 +192,21 @@ func (r *SenderReport) Unmarshal(rawPacket []byte) error {
 	}
 
 	return nil
+}
+
+func (r *SenderReport) len() int {
+	repsLength := 0
+	for _, rep := range r.Reports {
+		repsLength += rep.len()
+	}
+	return headerLength + srHeaderLength + repsLength
+}
+
+// Header returns the Header associated with this packet.
+func (r *SenderReport) Header() Header {
+	return Header{
+		Count:  uint8(len(r.Reports)),
+		Type:   TypeSenderReport,
+		Length: uint16((r.len() / 4) - 1),
+	}
 }


### PR DESCRIPTION
I did a little work on a change to the RTCP API today. Wanted to send for feedback early so I don't step on your shoes @wdouglass.

These changes add a RawPacket type for RTCP packet types we haven't seen yet and a type switch to simplify the output of Unmarshal.

In the next commit I'd like to add a `Header()` function to the `Packet` interface and make it so both `Unmarshal()` and `Reader.ReadPacket()` just return a parsed packet instead of a raw packet and header.