### PR TITLE
Add go-fuzzer support to RTCP package

### DIFF
--- a/pkg/rtcp/fuzz.go
+++ b/pkg/rtcp/fuzz.go
@@ -1,0 +1,51 @@
+// +build gofuzz
+
+package rtcp
+
+import (
+	"bytes"
+	"io"
+)
+
+// Fuzz implements a randomized fuzz test of the rtcp
+// parser using go-fuzz.
+//
+// To run the fuzzer, first download go-fuzz:
+// `go get github.com/dvyukov/go-fuzz/...`
+//
+// Then build the testing package:
+// `go-fuzz-build github.com/pions/webrtc`
+//
+// And run the fuzzer on the corpus:
+// ```
+// mkdir workdir
+//
+// # optionally add a starter corpus of valid rtcp packets.
+// # the corpus should be as compact and diverse as possible.
+// cp -r ~/my-rtcp-packets workdir/corpus
+//
+// go-fuzz -bin=ase-fuzz.zip -workdir=workdir
+// ````
+func Fuzz(data []byte) int {
+	r := NewReader(bytes.NewReader(data))
+	for {
+		_, data, err := r.ReadPacket()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0
+		}
+
+		packet, _, err := Unmarshal(data)
+		if err != nil {
+			return 0
+		}
+
+		if _, err := packet.Marshal(); err != nil {
+			return 0
+		}
+	}
+
+	return 1
+}


### PR DESCRIPTION
This will help find crashers and security issues lurking in our
parser code, and parser edge cases we haven't thought of yet.

Visit https://github.com/dvyukov/go-fuzz for more information

Relates to #251