### PR TITLE
Srtp fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Michael MacDonald](https://github.com/mjmac)
 * [Oleg Kovalov](https://github.com/cristaloleg) *Use wildcards instead of hardcoding travis-ci config*
 * [Woodrow Douglass](https://github.com/wdouglass) *Application notification of incoming RTCP messages*
+* [Tobias Fridén](https://github.com/tobiasfriden) *SRTP authentication verification
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -77,6 +77,12 @@ func NewManager(urls []*ice.URL, btg BufferTransportGenerator, dcet DataChannelE
 	return m, err
 }
 
+func (m *Manager) getBufferTransports(ssrc uint32) *TransportPair {
+	m.pairsLock.RLock()
+	defer m.pairsLock.RUnlock()
+	return m.bufferTransportPairs[ssrc]
+}
+
 func (m *Manager) getOrCreateBufferTransports(ssrc uint32, payloadtype uint8) *TransportPair {
 	m.pairsLock.Lock()
 	defer m.pairsLock.Unlock()

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -77,12 +77,6 @@ func NewManager(urls []*ice.URL, btg BufferTransportGenerator, dcet DataChannelE
 	return m, err
 }
 
-func (m *Manager) getBufferTransports(ssrc uint32) *TransportPair {
-	m.pairsLock.RLock()
-	defer m.pairsLock.RUnlock()
-	return m.bufferTransportPairs[ssrc]
-}
-
 func (m *Manager) getOrCreateBufferTransports(ssrc uint32, payloadtype uint8) *TransportPair {
 	m.pairsLock.Lock()
 	defer m.pairsLock.Unlock()
@@ -151,7 +145,7 @@ func (m *Manager) Start(isOffer bool,
 	if err != nil {
 		return err
 	}
-	if err = m.CreateContextSRTP(keyingMaterial); err != nil {
+	if err = m.CreateContextSRTP(keyingMaterial, isOffer); err != nil {
 		return err
 	}
 

--- a/internal/network/srtp.go
+++ b/internal/network/srtp.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	"github.com/pions/webrtc/internal/srtp"
-	"github.com/pions/webrtc/pkg/rtcp"
 	"github.com/pions/webrtc/pkg/rtp"
 	"github.com/pkg/errors"
 )
@@ -20,7 +18,7 @@ const (
 // TODO: Migrate to srtp.Conn
 
 // CreateContextSRTP takes the exported keying material from DTLS and creates Client/Server contexts
-func (m *Manager) CreateContextSRTP(keyingMaterial []byte) error {
+func (m *Manager) CreateContextSRTP(keyingMaterial []byte, isOffer bool) error {
 	offset := 0
 
 	clientWriteKey := append([]byte{}, keyingMaterial[offset:offset+srtpMasterKeyLen]...)
@@ -36,57 +34,28 @@ func (m *Manager) CreateContextSRTP(keyingMaterial []byte) error {
 
 	var err error
 	m.srtpInboundContextLock.Lock()
-	m.srtpInboundContext, err = srtp.CreateContext(serverWriteKey[0:16], serverWriteKey[16:] /* Profile */, "")
+	if isOffer {
+		m.srtpInboundContext, err = srtp.CreateContext(clientWriteKey[0:16], clientWriteKey[16:] /* Profile */, "")
+	} else {
+		m.srtpInboundContext, err = srtp.CreateContext(serverWriteKey[0:16], serverWriteKey[16:] /* Profile */, "")
+	}
 	m.srtpInboundContextLock.Unlock()
 	if err != nil {
 		return errors.New("failed to build inbound SRTP context")
 	}
 
 	m.srtpOutboundContextLock.Lock()
-	m.srtpOutboundContext, err = srtp.CreateContext(clientWriteKey[0:16], clientWriteKey[16:] /* Profile */, "")
+	if isOffer {
+		m.srtpOutboundContext, err = srtp.CreateContext(serverWriteKey[0:16], serverWriteKey[16:] /* Profile */, "")
+	} else {
+		m.srtpOutboundContext, err = srtp.CreateContext(clientWriteKey[0:16], clientWriteKey[16:] /* Profile */, "")
+	}
 	m.srtpOutboundContextLock.Unlock()
 	if err != nil {
 		return errors.New("failed to build outbound SRTP context")
 	}
 
 	return nil
-}
-
-func handleRTCP(getBufferTransports func(uint32) *TransportPair, buffer []byte) {
-	//decrypted packets can also be compound packets, so we have to nest our reader loop here.
-	compoundPacket := rtcp.NewReader(bytes.NewReader(buffer))
-	for {
-		_, rawrtcp, err := compoundPacket.ReadPacket()
-
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			fmt.Println(err)
-			return
-		}
-
-		var report rtcp.Packet
-		report, _, err = rtcp.Unmarshal(rawrtcp)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-
-		f := func(ssrc uint32) {
-			bufferTransport := getBufferTransports(ssrc)
-			if bufferTransport != nil && bufferTransport.RTCP != nil {
-				select {
-				case bufferTransport.RTCP <- report:
-				default:
-				}
-			}
-		}
-
-		for _, ssrc := range report.DestinationSSRC() {
-			f(ssrc)
-		}
-	}
 }
 
 func (m *Manager) handleSRTP(buffer []byte) {
@@ -113,8 +82,6 @@ func (m *Manager) handleSRTP(buffer []byte) {
 				fmt.Println(decrypted)
 				return
 			}
-
-			handleRTCP(m.getBufferTransports, decrypted)
 			return
 		}
 	}
@@ -131,11 +98,9 @@ func (m *Manager) handleSRTP(buffer []byte) {
 	}
 
 	bufferTransport := m.getOrCreateBufferTransports(packet.SSRC, packet.PayloadType)
-	if bufferTransport != nil && bufferTransport.RTP != nil {
-		select {
-		case bufferTransport.RTP <- packet:
-		default:
-		}
+	select {
+	case bufferTransport.RTP <- packet:
+	default:
 	}
 
 }

--- a/internal/srtp/context.go
+++ b/internal/srtp/context.go
@@ -222,5 +222,5 @@ func (c *Context) verifyAuthTag(buf, expectedAuthTag, authTag []byte) (bool, err
 	if _, err := mac.Write(buf); err != nil {
 		return false, err
 	}
-	return bytes.Compare(expectedAuthTag, mac.Sum(nil)[0:10]) == 0, nil
+	return bytes.Equal(expectedAuthTag, mac.Sum(nil)[0:10]), nil
 }

--- a/internal/srtp/srtp.go
+++ b/internal/srtp/srtp.go
@@ -13,6 +13,7 @@ func (c *Context) DecryptRTP(packet *rtp.Packet) bool {
 
 	c.updateRolloverCount(packet.SequenceNumber, s)
 
+	// Extract auth tag and verify it
 	auth := packet.Payload[len(packet.Payload)-10:]
 	fullPkt := packet.Raw[:]
 	fullPkt = append(fullPkt, make([]byte, 4)...)

--- a/internal/srtp/srtp_test.go
+++ b/internal/srtp/srtp_test.go
@@ -126,6 +126,7 @@ func TestRTPLifecyle(t *testing.T) {
 	assert := assert.New(t)
 	masterKey := []byte{0x0d, 0xcd, 0x21, 0x3e, 0x4c, 0xbc, 0xf2, 0x8f, 0x01, 0x7f, 0x69, 0x94, 0x40, 0x1e, 0x28, 0x89}
 	masterSalt := []byte{0x62, 0x77, 0x60, 0x38, 0xc0, 0x6d, 0xc9, 0x41, 0x9f, 0x6d, 0xd9, 0x43, 0x3e, 0x7c}
+	invalidSalt := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 
 	encryptContext, err := CreateContext(masterKey, masterSalt, cipherContextAlgo)
 	if err != nil {
@@ -136,7 +137,10 @@ func TestRTPLifecyle(t *testing.T) {
 	if err != nil {
 		t.Error(errors.Wrap(err, "CreateContext failed"))
 	}
-
+	invalidContext, err := CreateContext(masterKey, invalidSalt, cipherContextAlgo)
+	if err != nil {
+		t.Error(errors.Wrap(err, "CreateContext failed"))
+	}
 	decrypted := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
 	var testCases = []rtpTestCase{
 		{
@@ -173,6 +177,14 @@ func TestRTPLifecyle(t *testing.T) {
 		}
 		assert.Equalf(pkt.Payload, decrypted, "RTP packet with SeqNum invalid decryption: %d", testCase.sequenceNumber)
 
+	}
+
+	for _, testCase := range testCases {
+		pkt := &rtp.Packet{Payload: append([]byte{}, decrypted...), SequenceNumber: testCase.sequenceNumber}
+		encryptContext.EncryptRTP(pkt)
+		if invalidContext.DecryptRTP(pkt) {
+			t.Errorf("Managed to decrypt with incorrect salt for packet with SeqNum: %d", testCase.sequenceNumber)
+		}
 	}
 }
 


### PR DESCRIPTION
Implements two fixes related to SRTP:

- Introduce a parameter to reverse the keys used in `CreateContextSRTP` depending on if pions is creating the offer or not

- Check that incoming SRTP packets have the correct authorization tag

Resolves #261 