### PR TITLE
Allow local ephemeral port range to be limited

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -66,19 +66,9 @@ func (m *Manager) AddTransportPair(ssrc uint32, Rtp chan<- *rtp.Packet, Rtcp cha
 }
 
 // NewManager creates a new network.Manager
-func NewManager(urls []*ice.URL, btg BufferTransportGenerator, ntf ICENotifier) *Manager {
-	iceAgent := ice.NewAgent(urls, ntf)
-
-	return &Manager{
-		IceAgent:                 iceAgent,
-		bufferTransportPairs:     make(map[uint32]*TransportPair),
-		bufferTransportGenerator: btg,
-	}
-}
-
-// NewLimitedManager creates a new network.Manager (and a UDP limited ICE agent)
-func NewLimitedManager(urls []*ice.URL, btg BufferTransportGenerator, ntf ICENotifier, minport, maxport uint16) (*Manager, error) {
-	iceAgent, err := ice.NewLimitedAgent(urls, ntf, minport, maxport)
+func NewManager(urls []*ice.URL, btg BufferTransportGenerator, ntf ICENotifier, minport, maxport uint16) (*Manager, error) {
+	config := &ice.AgentConfig{Urls: urls, Notifier: ntf, PortMin: minport, PortMax: maxport}
+	iceAgent, err := ice.NewAgent(config)
 
 	if err != nil {
 		return nil, err

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -76,6 +76,21 @@ func NewManager(urls []*ice.URL, btg BufferTransportGenerator, ntf ICENotifier) 
 	}
 }
 
+// NewLimitedManager creates a new network.Manager (and a UDP limited ICE agent)
+func NewLimitedManager(urls []*ice.URL, btg BufferTransportGenerator, ntf ICENotifier, minport, maxport uint16) (*Manager, error) {
+	iceAgent, err := ice.NewLimitedAgent(urls, ntf, minport, maxport)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		IceAgent:                 iceAgent,
+		bufferTransportPairs:     make(map[uint32]*TransportPair),
+		bufferTransportGenerator: btg,
+	}, nil
+}
+
 func (m *Manager) getBufferTransports(ssrc uint32) *TransportPair {
 	m.pairsLock.RLock()
 	defer m.pairsLock.RUnlock()

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -91,7 +91,7 @@ func (a *Agent) getErr() error {
 	return ErrClosed
 }
 
-// AgentConfig collects the arguements to ice.Agent construction into
+// AgentConfig collects the arguments to ice.Agent construction into
 // a single structure, for future-proofness of the interface
 type AgentConfig struct {
 	Urls     []*URL

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -91,11 +91,15 @@ func (a *Agent) getErr() error {
 	return ErrClosed
 }
 
+// AgentConfig collects the arguements to ice.Agent construction into
+// a single structure, for future-proofness of the interface
 type AgentConfig struct {
 	Urls     []*URL
 	Notifier func(ConnectionState)
-	PortMin  uint16
-	PortMax  uint16
+
+	// PortMin and PortMax are optional. Leave them 0 for the default UDP port allocation strategy.
+	PortMin uint16
+	PortMax uint16
 }
 
 // NewAgent creates a new Agent

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -117,15 +117,19 @@ func NewAgent(urls []*URL, notifier func(ConnectionState)) *Agent {
 	return a
 }
 
-// SetLocalPortRange allows the range of local ephemeral ports used by the
-// ICE agent to be limited.
-func (a *Agent) SetLocalPortRange(min, max uint16) error {
+// NewLimitedAgent creates a new agent, which limits the ephemeral UDP ports it allocates
+// This is usually not required, and not part of the WebRTC protocol, but may be helpful
+// in some edge cases. It's also important to note that this limitation only affects host
+// candidates, and not reflective candidates.
+func NewLimitedAgent(urls []*URL, notifier func(ConnectionState), min, max uint16) (*Agent, error) {
 	if max < min {
-		return ErrPort
+		return nil, ErrPort
 	}
+
+	a := NewAgent(urls, notifier)
 	a.portmin = min
 	a.portmax = max
-	return nil
+	return a, nil
 }
 
 func (a *Agent) listenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {

--- a/pkg/ice/transport_test.go
+++ b/pkg/ice/transport_test.go
@@ -78,8 +78,19 @@ func pipe() (*Conn, *Conn) {
 	aNotifier, aConnected := onConnected()
 	bNotifier, bConnected := onConnected()
 
-	aAgent := NewAgent(urls, aNotifier)
-	bAgent := NewAgent(urls, bNotifier)
+	aAgent, err := NewAgent(&AgentConfig{Urls: urls, Notifier: aNotifier})
+
+	if err != nil {
+		//we should never get here.
+		panic(err)
+	}
+
+	bAgent, err := NewAgent(&AgentConfig{Urls: urls, Notifier: bNotifier})
+
+	if err != nil {
+		//we should never get here.
+		panic(err)
+	}
 
 	// Manual signaling
 	aUfrag, aPwd := aAgent.GetLocalUserCredentials()

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -44,11 +44,6 @@ type RTCConfiguration struct {
 
 	// IceCandidatePoolSize describes the size of the prefetched ICE pool.
 	IceCandidatePoolSize uint8
-
-	// MinLocalPort and MaxLocalPort, if nonzero, set limits to local ephemeral
-	// UDP ports that are allocated by the ICE agent.
-	MinLocalPort uint16
-	MaxLocalPort uint16
 }
 
 func (c RTCConfiguration) getIceServers() (*[]*ice.URL, error) {

--- a/rtcconfiguration.go
+++ b/rtcconfiguration.go
@@ -44,6 +44,11 @@ type RTCConfiguration struct {
 
 	// IceCandidatePoolSize describes the size of the prefetched ICE pool.
 	IceCandidatePoolSize uint8
+
+	// MinLocalPort and MaxLocalPort, if nonzero, set limits to local ephemeral
+	// UDP ports that are allocated by the ICE agent.
+	MinLocalPort uint16
+	MaxLocalPort uint16
 }
 
 func (c RTCConfiguration) getIceServers() (*[]*ice.URL, error) {

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -160,6 +160,13 @@ func New(configuration RTCConfiguration) (*RTCPeerConnection, error) {
 
 	pc.networkManager = network.NewManager(urls, pc.generateChannel, pc.iceStateChange)
 
+	if (configuration.MinLocalPort != 0) || (configuration.MaxLocalPort != 0) {
+		err := pc.networkManager.IceAgent.SetLocalPortRange(configuration.MinLocalPort, configuration.MaxLocalPort)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &pc, nil
 }
 

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -158,13 +158,9 @@ func New(configuration RTCConfiguration) (*RTCPeerConnection, error) {
 		}
 	}
 
-	if (configuration.MinLocalPort != 0) || (configuration.MaxLocalPort != 0) {
-		pc.networkManager, err = network.NewLimitedManager(urls, pc.generateChannel, pc.iceStateChange, configuration.MinLocalPort, configuration.MaxLocalPort)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		pc.networkManager = network.NewManager(urls, pc.generateChannel, pc.iceStateChange)
+	pc.networkManager, err = network.NewManager(urls, pc.generateChannel, pc.iceStateChange, configuration.MinLocalPort, configuration.MaxLocalPort)
+	if err != nil {
+		return nil, err
 	}
 
 	return &pc, nil

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -158,13 +158,13 @@ func New(configuration RTCConfiguration) (*RTCPeerConnection, error) {
 		}
 	}
 
-	pc.networkManager = network.NewManager(urls, pc.generateChannel, pc.iceStateChange)
-
 	if (configuration.MinLocalPort != 0) || (configuration.MaxLocalPort != 0) {
-		err := pc.networkManager.IceAgent.SetLocalPortRange(configuration.MinLocalPort, configuration.MaxLocalPort)
+		pc.networkManager, err = network.NewLimitedManager(urls, pc.generateChannel, pc.iceStateChange, configuration.MinLocalPort, configuration.MaxLocalPort)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		pc.networkManager = network.NewManager(urls, pc.generateChannel, pc.iceStateChange)
 	}
 
 	return &pc, nil

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -158,7 +158,7 @@ func New(configuration RTCConfiguration) (*RTCPeerConnection, error) {
 		}
 	}
 
-	pc.networkManager, err = network.NewManager(urls, pc.generateChannel, pc.iceStateChange, configuration.MinLocalPort, configuration.MaxLocalPort)
+	pc.networkManager, err = network.NewManager(urls, pc.generateChannel, pc.iceStateChange, defaultSettingEngine.EphemeralUDP.PortMin, defaultSettingEngine.EphemeralUDP.PortMax)
 	if err != nil {
 		return nil, err
 	}

--- a/settingengine.go
+++ b/settingengine.go
@@ -1,0 +1,28 @@
+package webrtc
+
+import "github.com/pions/webrtc/pkg/ice"
+
+var defaultSettingEngine = newSettingEngine()
+
+type settingEngine struct {
+	EphemeralUDP struct {
+		PortMin uint16
+		PortMax uint16
+	}
+}
+
+// SetEphemeralUDPPortRange limits the pool of ephemeral ports that
+// ICE UDP connections can allocate from
+func SetEphemeralUDPPortRange(portMin, portMax uint16) error {
+	if portMax < portMin {
+		return ice.ErrPort
+	}
+
+	defaultSettingEngine.EphemeralUDP.PortMin = portMin
+	defaultSettingEngine.EphemeralUDP.PortMax = portMax
+	return nil
+}
+
+func newSettingEngine() *settingEngine {
+	return new(settingEngine)
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -4,6 +4,9 @@ import "github.com/pions/webrtc/pkg/ice"
 
 var defaultSettingEngine = newSettingEngine()
 
+// settingEngine allows influencing behavior in ways that are not
+// supported by the WebRTC API. This allows us to support additional
+// use-cases without deviating from the WebRTC API elsewhere.
 type settingEngine struct {
 	EphemeralUDP struct {
 		PortMin uint16
@@ -12,7 +15,8 @@ type settingEngine struct {
 }
 
 // SetEphemeralUDPPortRange limits the pool of ephemeral ports that
-// ICE UDP connections can allocate from
+// ICE UDP connections can allocate from. This setting currently only
+// affects host candidates, not server reflexive candidates.
 func SetEphemeralUDPPortRange(portMin, portMax uint16) error {
 	if portMax < portMin {
 		return ice.ErrPort


### PR DESCRIPTION
This allows primitive (non-stateful) firewalls to have less wide-open configuration, while still maintaining some chance of getting UDP packets out...