### PR TITLE
Ignore case when parsing candidate networkType

### DIFF
--- a/pkg/ice/networktype.go
+++ b/pkg/ice/networktype.go
@@ -83,13 +83,13 @@ func DetermineNetworkType(network string, ip net.IP) NetworkType {
 	ipv4 := ip.To4() != nil
 
 	switch {
-	case strings.HasPrefix(network, udp):
+	case strings.HasPrefix(strings.ToLower(network), udp):
 		if ipv4 {
 			return NetworkTypeUDP4
 		}
 		return NetworkTypeUDP6
 
-	case strings.HasPrefix(network, tcp):
+	case strings.HasPrefix(strings.ToLower(network), tcp):
 		if ipv4 {
 			return NetworkTypeTCP4
 		}

--- a/pkg/ice/networktype_test.go
+++ b/pkg/ice/networktype_test.go
@@ -1,0 +1,55 @@
+package ice
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNetworkTypeParsing(t *testing.T) {
+	ipv4 := net.ParseIP("192.168.0.1")
+	ipv6 := net.ParseIP("fe80::a3:6ff:fec4:5454")
+
+	for _, test := range []struct {
+		name      string
+		inNetwork string
+		inIP      net.IP
+		expected  NetworkType
+	}{
+		{
+			"lowercase UDP4",
+			"udp",
+			ipv4,
+			NetworkTypeUDP4,
+		},
+		{
+			"uppercase UDP4",
+			"UDP",
+			ipv4,
+			NetworkTypeUDP4,
+		},
+		{
+			"lowercase UDP6",
+			"udp",
+			ipv6,
+			NetworkTypeUDP6,
+		},
+		{
+			"uppercase UDP6",
+			"UDP",
+			ipv6,
+			NetworkTypeUDP6,
+		},
+		{
+			"invalid network",
+			"junkNetwork",
+			ipv6,
+			NetworkType(0),
+		},
+	} {
+		actual := DetermineNetworkType(test.inNetwork, test.inIP)
+		if actual != test.expected {
+			t.Errorf("NetworkTypeParsing: '%s' -- input:%s expected:%s actual:%s",
+				test.name, test.inNetwork, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Before we would fail to parse networkType if it was upcased. Also return
errors when networkType is unknown

Resolves #289