### PR TITLE
SDP: Change Media Descriptions fmt to string

### DIFF
--- a/internal/sdp/jsep.go
+++ b/internal/sdp/jsep.go
@@ -131,7 +131,7 @@ func (d *MediaDescription) WithICECredentials(username, password string) *MediaD
 
 // WithCodec adds codec information to the media description
 func (d *MediaDescription) WithCodec(payloadType uint8, name string, clockrate uint32, channels uint16, fmtp string) *MediaDescription {
-	d.MediaName.Formats = append(d.MediaName.Formats, int(payloadType))
+	d.MediaName.Formats = append(d.MediaName.Formats, string(payloadType))
 	rtpmap := fmt.Sprintf("%d %s/%d", payloadType, name, clockrate)
 	if channels > 0 {
 		rtpmap = rtpmap + fmt.Sprintf("/%d", channels)

--- a/internal/sdp/marshal_test.go
+++ b/internal/sdp/marshal_test.go
@@ -120,7 +120,7 @@ func TestMarshalCanonical(t *testing.T) {
 						Value: 49170,
 					},
 					Protos:  []string{"RTP", "AVP"},
-					Formats: []int{0},
+					Formats: []string{"0"},
 				},
 				MediaTitle: &(&struct{ x Information }{"Vivamus a posuere nisl"}).x,
 				ConnectionInformation: &ConnectionInformation{
@@ -149,7 +149,7 @@ func TestMarshalCanonical(t *testing.T) {
 						Value: 51372,
 					},
 					Protos:  []string{"RTP", "AVP"},
-					Formats: []int{99},
+					Formats: []string{"99"},
 				},
 				Attributes: []Attribute{
 					NewAttribute("rtpmap:99 h263-1998/90000", ""),

--- a/internal/sdp/media_description.go
+++ b/internal/sdp/media_description.go
@@ -67,20 +67,15 @@ type MediaName struct {
 	Media   string
 	Port    RangedPort
 	Protos  []string
-	Formats []int
+	Formats []string
 }
 
 func (m *MediaName) String() *string {
-	formats := make([]string, 0)
-	for _, format := range m.Formats {
-		formats = append(formats, strconv.Itoa(format))
-	}
-
 	output := strings.Join([]string{
 		m.Media,
 		m.Port.String(),
 		strings.Join(m.Protos, "/"),
-		strings.Join(formats, " "),
+		strings.Join(m.Formats, " "),
 	}, " ")
 	return &output
 }

--- a/internal/sdp/unmarshal.go
+++ b/internal/sdp/unmarshal.go
@@ -842,11 +842,7 @@ func unmarshalMediaDescription(l *lexer) (stateFn, error) {
 
 	// <fmt>...
 	for i := 3; i < len(fields); i++ {
-		format, err := strconv.Atoi(fields[i])
-		if err != nil {
-			return nil, errors.Errorf("sdp: invalid numeric value `%v`", fields[i])
-		}
-		newMediaDesc.MediaName.Formats = append(newMediaDesc.MediaName.Formats, format)
+		newMediaDesc.MediaName.Formats = append(newMediaDesc.MediaName.Formats, fields[i])
 	}
 
 	l.desc.MediaDescriptions = append(l.desc.MediaDescriptions, newMediaDesc)

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -1219,7 +1219,7 @@ func (pc *RTCPeerConnection) addDataMediaSection(d *sdp.SessionDescription, midV
 			Media:   "application",
 			Port:    sdp.RangedPort{Value: 9},
 			Protos:  []string{"DTLS", "SCTP"},
-			Formats: []int{5000},
+			Formats: []string{"5000"},
 		},
 		ConnectionInformation: &sdp.ConnectionInformation{
 			NetworkType: "IN",


### PR DESCRIPTION
We don't mirror the format in the answer as described [here](https://blog.mozilla.org/webrtc/how-to-avoid-data-channel-breaking/) but just fixing the parsing does fix Firefox support.

Resolves #208