### PR TITLE
Detach: Expose data channel networking

### DIFF
--- a/examples/data-channels-detach-create/README.md
+++ b/examples/data-channels-detach-create/README.md
@@ -1,0 +1,12 @@
+# data-channels
+data-channels-detach-create is an example that shows how you can detach a data channel. This allows direct access the the underlying [pions/datachannel](https://github.com/pions/datachannel). This allows you to interact with the data channel using a more idiomatic API based on the `io.ReadWriteCloser` interface.
+
+The example mirrors the data-channels-create example.
+
+## Install
+```
+go get github.com/pions/webrtc/examples/data-channels-detach-create
+```
+
+## Usage
+The example can be used in the same way as the data-channel example or can be paired with the data-channels-detach example. In the latter case; run both example and exchange the offer/answer text by copy-pasting them on the other terminal.

--- a/examples/data-channels-detach-create/main.go
+++ b/examples/data-channels-detach-create/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pions/datachannel"
+	"github.com/pions/webrtc"
+	"github.com/pions/webrtc/examples/util"
+	"github.com/pions/webrtc/pkg/ice"
+)
+
+const messageSize = 15
+
+func main() {
+	// Since this behavior diverges from the WebRTC API it has to be
+	// enabled using global switch.
+	// Mixing both behaviors is not supported.
+	webrtc.DetachDataChannels()
+
+	// Everything below is the pion-WebRTC API! Thanks for using it ❤️.
+
+	// Prepare the configuration
+	config := webrtc.RTCConfiguration{
+		IceServers: []webrtc.RTCIceServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	}
+
+	// Create a new RTCPeerConnection
+	peerConnection, err := webrtc.New(config)
+	util.Check(err)
+
+	// Create a datachannel with label 'data'
+	dataChannel, err := peerConnection.CreateDataChannel("data", nil)
+	util.Check(err)
+
+	// Set the handler for ICE connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
+		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
+	})
+
+	// Register channel opening handling
+	dataChannel.OnOpen(func() {
+		fmt.Printf("Data channel '%s'-'%d' open.\n", dataChannel.Label, dataChannel.ID)
+
+		// Detach the data channel
+		raw, dErr := dataChannel.Detach()
+		util.Check(dErr)
+
+		// Handle reading from the data channel
+		go ReadLoop(raw)
+
+		// Handle writing to the data channel
+		go WriteLoop(raw)
+	})
+
+	// Create an offer to send to the browser
+	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	// Output the offer in base64 so we can paste it in browser
+	fmt.Println(util.Encode(offer))
+
+	// Wait for the answer to be pasted
+	answer := util.Decode(util.MustReadStdin())
+
+	// Apply the answer as the remote description
+	err = peerConnection.SetRemoteDescription(answer)
+	util.Check(err)
+
+	// Block forever
+	select {}
+}
+
+// ReadLoop shows how to read from the datachannel directly
+func ReadLoop(d *datachannel.DataChannel) {
+	for {
+		buffer := make([]byte, messageSize)
+		n, err := d.Read(buffer)
+		if err != nil {
+			fmt.Println("Datachannel closed; Exit the readloop:", err)
+			return
+		}
+
+		fmt.Printf("Message from DataChannel '%s': %s\n", d.Label, string(buffer[:n]))
+	}
+}
+
+// WriteLoop shows how to write to the datachannel directly
+func WriteLoop(d *datachannel.DataChannel) {
+	for range time.NewTicker(5 * time.Second).C {
+		message := util.RandSeq(messageSize)
+		fmt.Printf("Sending %s \n", message)
+
+		_, err := d.Write([]byte(message))
+		util.Check(err)
+	}
+}

--- a/examples/data-channels-detach/README.md
+++ b/examples/data-channels-detach/README.md
@@ -1,0 +1,12 @@
+# data-channels
+data-channels-detach is an example that shows how you can detach a data channel. This allows direct access the the underlying [pions/datachannel](https://github.com/pions/datachannel). This allows you to interact with the data channel using a more idiomatic API based on the `io.ReadWriteCloser` interface.
+
+The example mirrors the data-channels example.
+
+## Install
+```
+go get github.com/pions/webrtc/examples/data-channels-detach
+```
+
+## Usage
+The example can be used in the same way as the data-channel example or can be paired with the data-channels-detach-create example. In the latter case; run both example and exchange the offer/answer text by copy-pasting them on the other terminal.

--- a/examples/data-channels-detach/main.go
+++ b/examples/data-channels-detach/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pions/datachannel"
+	"github.com/pions/webrtc"
+	"github.com/pions/webrtc/examples/util"
+	"github.com/pions/webrtc/pkg/ice"
+)
+
+const messageSize = 15
+
+func main() {
+	// Since this behavior diverges from the WebRTC API it has to be
+	// enabled using global switch.
+	// Mixing both behaviors is not supported.
+	webrtc.DetachDataChannels()
+
+	// Everything below is the pion-WebRTC API! Thanks for using it ❤️.
+
+	// Prepare the configuration
+	config := webrtc.RTCConfiguration{
+		IceServers: []webrtc.RTCIceServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	}
+
+	// Create a new RTCPeerConnection
+	peerConnection, err := webrtc.New(config)
+	util.Check(err)
+
+	// Set the handler for ICE connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
+		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
+	})
+
+	// Register data channel creation handling
+	peerConnection.OnDataChannel(func(d *webrtc.RTCDataChannel) {
+		fmt.Printf("New DataChannel %s %d\n", d.Label, d.ID)
+
+		// Register channel opening handling
+		d.OnOpen(func() {
+			fmt.Printf("Data channel '%s'-'%d' open.\n", d.Label, d.ID)
+
+			// Detach the data channel
+			raw, dErr := d.Detach()
+			util.Check(dErr)
+
+			// Handle reading from the data channel
+			go ReadLoop(raw)
+
+			// Handle writing to the data channel
+			go WriteLoop(raw)
+		})
+	})
+
+	// Wait for the offer to be pasted
+	offer := util.Decode(util.MustReadStdin())
+
+	// Set the remote SessionDescription
+	err = peerConnection.SetRemoteDescription(offer)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Output the answer in base64 so we can paste it in browser
+	fmt.Println(util.Encode(answer))
+
+	// Block forever
+	select {}
+}
+
+// ReadLoop shows how to read from the datachannel directly
+func ReadLoop(d *datachannel.DataChannel) {
+	for {
+		buffer := make([]byte, messageSize)
+		n, err := d.Read(buffer)
+		if err != nil {
+			fmt.Println("Datachannel closed; Exit the readloop:", err)
+			return
+		}
+
+		fmt.Printf("Message from DataChannel '%s': %s\n", d.Label, string(buffer[:n]))
+	}
+}
+
+// WriteLoop shows how to write to the datachannel directly
+func WriteLoop(d *datachannel.DataChannel) {
+	for range time.NewTicker(5 * time.Second).C {
+		message := util.RandSeq(messageSize)
+		fmt.Printf("Sending %s \n", message)
+
+		_, err := d.Write([]byte(message))
+		util.Check(err)
+	}
+}

--- a/settingengine.go
+++ b/settingengine.go
@@ -4,16 +4,6 @@ import "github.com/pions/webrtc/pkg/ice"
 
 var defaultSettingEngine = newSettingEngine()
 
-// settingEngine allows influencing behavior in ways that are not
-// supported by the WebRTC API. This allows us to support additional
-// use-cases without deviating from the WebRTC API elsewhere.
-type settingEngine struct {
-	EphemeralUDP struct {
-		PortMin uint16
-		PortMax uint16
-	}
-}
-
 // SetEphemeralUDPPortRange limits the pool of ephemeral ports that
 // ICE UDP connections can allocate from. This setting currently only
 // affects host candidates, not server reflexive candidates.
@@ -25,6 +15,33 @@ func SetEphemeralUDPPortRange(portMin, portMax uint16) error {
 	defaultSettingEngine.EphemeralUDP.PortMin = portMin
 	defaultSettingEngine.EphemeralUDP.PortMax = portMax
 	return nil
+}
+
+// DetachDataChannels enables detaching data channels. When enabled
+// data channels have to be detached in the OnOpen callback using the
+// RTCDataChannel.Detach method.
+func DetachDataChannels() {
+	defaultSettingEngine.DetachDataChannels()
+}
+
+// settingEngine allows influencing behavior in ways that are not
+// supported by the WebRTC API. This allows us to support additional
+// use-cases without deviating from the WebRTC API elsewhere.
+type settingEngine struct {
+	EphemeralUDP struct {
+		PortMin uint16
+		PortMax uint16
+	}
+	Detach struct {
+		DataChannels bool
+	}
+}
+
+// DetachDataChannels enables detaching data channels. When enabled
+// data channels have to be detached in the OnOpen callback using the
+// RTCDataChannel.Detach method.
+func (e *settingEngine) DetachDataChannels() {
+	e.Detach.DataChannels = true
 }
 
 func newSettingEngine() *settingEngine {


### PR DESCRIPTION
This is the initial experiment towards providing direct access to the data channel as described in #277. Once detached the `io.ReadWriter` API feels very familiar. In addition, this seems really powerful for more networking oriented applications. E.g.: a lot of silly glue logic could be removed from `pions/dcnet`.

If you want to build this branch right now, you have to manually move the `sctp` and `datachannel` package under the pions root.

TODO:
- [ ] Finalize API: There is currently no good place to call the detach method. The prerequisites are that the `datachannel.DataChannel` object exists but the `RTCDataChannel.readLoop` is not yet started. Some potential solution:
    - `OnOpen` seems like a good candidate but it is asynchronous ATM.
    - Signal early that you want to detach somehow (settings manager?) and have a method to get the `datachannel.DataChannel` object once it exists.
    - Add an OnDetach callback. However, this would also suffer from #305. Preferably we won't have to solve this twice.
- [x] Correctly move package `sctp` out of tree.
- [x] Correctly move package `datachannel` out of tree.
- [ ] Finalize `data-channels-detach` example.
- [ ] Create `data-channels-detach-create` example.