### PR TITLE
Fix keepalive transmission interval mentioned in issue #331

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Oleg Kovalov](https://github.com/cristaloleg) *Use wildcards instead of hardcoding travis-ci config*
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Tobias Fridén](https://github.com/tobiasfriden) *SRTP authentication verification*
+* [Yutaka Takeda](https://github.com/enobufs) *Fix ICE connection timeout*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -418,7 +418,7 @@ func (a *Agent) checkKeepalive() {
 		return
 	}
 
-	if time.Since(a.selectedPair.remote.LastSent()) > keepaliveInterval {
+	if time.Since(a.selectedPair.local.LastSent()) > keepaliveInterval {
 		a.keepaliveCandidate(a.selectedPair.local, a.selectedPair.remote)
 	}
 }


### PR DESCRIPTION
The `lastSent` value on a remote component of selected-pair never gets updated, which was the reason why LastSent() returned a large duration, causing the keepalive packet sent every 2 seconds.