### PR TITLE
Better defaults for lossy realtime VP8

### DIFF
--- a/examples/util/gstreamer-src/gst.go
+++ b/examples/util/gstreamer-src/gst.go
@@ -36,7 +36,7 @@ func CreatePipeline(codecName string, in chan<- media.RTCSample, pipelineSrc str
 	pipelineStr := "appsink name=appsink"
 	switch codecName {
 	case webrtc.VP8:
-		pipelineStr = pipelineSrc + " ! vp8enc ! " + pipelineStr
+		pipelineStr = pipelineSrc + " ! vp8enc error-resilient=partitions keyframe-max-dist=10 auto-alt-ref=true cpu-used=5 deadline=1 ! " + pipelineStr
 	case webrtc.VP9:
 		pipelineStr = pipelineSrc + " ! vp9enc ! " + pipelineStr
 	case webrtc.H264:


### PR DESCRIPTION
Update GStreamer examples to use some better defaults for real time
video. This isn't perfect, but improves the default experience for users
a little bit.

Relates to #303