### PR TITLE
[WIP] Add NTP time types

### DIFF
--- a/examples/util/gstreamer-src/gst.go
+++ b/examples/util/gstreamer-src/gst.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"sync"
 	"unsafe"
+	"time"
 
 	"github.com/pions/webrtc"
 	"github.com/pions/webrtc/pkg/media"
@@ -87,13 +88,7 @@ func goHandlePipelineBuffer(buffer unsafe.Pointer, bufferLen C.int, duration C.i
 	defer pipelinesLock.Unlock()
 
 	if pipeline, ok := pipelines[int(pipelineID)]; ok {
-		var samples uint32
-		if pipeline.codecName == webrtc.Opus {
-			samples = uint32(audioClockRate * (float32(duration) / 1000000000))
-		} else {
-			samples = uint32(videoClockRate * (float32(duration) / 1000000000))
-		}
-		pipeline.in <- media.RTCSample{Data: C.GoBytes(buffer, bufferLen), Samples: samples}
+		pipeline.in <- media.RTCSample{Data: C.GoBytes(buffer, bufferLen), Duration: time.Duration(duration)}
 	} else {
 		fmt.Printf("discarding buffer, no pipeline with id %d", int(pipelineID))
 	}

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -1,7 +1,9 @@
 package media
 
+import "time"
+
 // RTCSample contains media, and the amount of samples in it
 type RTCSample struct {
-	Data    []byte
-	Samples uint32
+	Data     []byte
+	Duration time.Duration
 }

--- a/pkg/media/samplebuilder/samplebuilder.go
+++ b/pkg/media/samplebuilder/samplebuilder.go
@@ -2,6 +2,7 @@ package samplebuilder
 
 import (
 	"github.com/pions/webrtc/pkg/media"
+	"github.com/pions/webrtc/pkg/ntp"
 	"github.com/pions/webrtc/pkg/rtp"
 )
 
@@ -21,7 +22,7 @@ type SampleBuilder struct {
 	// Last seqnum that has been successfully popped
 	hasPopped        bool
 	lastPopSeq       uint16
-	lastPopTimestamp uint32
+	lastPopTimestamp ntp.Time32
 }
 
 // New constructs a new SampleBuilder
@@ -50,14 +51,14 @@ func (s *SampleBuilder) buildSample(firstBuffer uint16) *media.RTCSample {
 				lastTimeStamp = s.buffer[firstBuffer-1].Timestamp
 			}
 
-			samples := s.buffer[i-1].Timestamp - lastTimeStamp
+			duration := (s.buffer[i-1].Timestamp - lastTimeStamp).Duration()
 			s.lastPopSeq = i - 1
 			s.hasPopped = true
 			s.lastPopTimestamp = s.buffer[i-1].Timestamp
 			for j := firstBuffer; j < i; j++ {
 				s.buffer[j] = nil
 			}
-			return &media.RTCSample{Data: data, Samples: samples}
+			return &media.RTCSample{Data: data, Duration: duration}
 		}
 
 		p, err := s.depacketizer.Unmarshal(s.buffer[i])

--- a/pkg/media/samplebuilder/samplebuilder_test.go
+++ b/pkg/media/samplebuilder/samplebuilder_test.go
@@ -2,6 +2,7 @@ package samplebuilder
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pions/webrtc/pkg/media"
 	"github.com/pions/webrtc/pkg/rtp"
@@ -34,34 +35,34 @@ var testCases = []sampleBuilderTest{
 	{
 		message: "SampleBuilder should emit one packet, we had three packets with unique timestamps",
 		packets: []*rtp.Packet{
-			{SequenceNumber: 5000, Timestamp: 5, Payload: []byte{0x01}},
-			{SequenceNumber: 5001, Timestamp: 6, Payload: []byte{0x02}},
-			{SequenceNumber: 5002, Timestamp: 7, Payload: []byte{0x03}},
+			{SequenceNumber: 5000, Timestamp: 0x00050000, Payload: []byte{0x01}},
+			{SequenceNumber: 5001, Timestamp: 0x00060000, Payload: []byte{0x02}},
+			{SequenceNumber: 5002, Timestamp: 0x00070000, Payload: []byte{0x03}},
 		},
 		samples: []*media.RTCSample{
-			{Data: []byte{0x02}, Samples: 1},
+			{Data: []byte{0x02}, Duration: time.Second},
 		},
 		bufferSize: 50,
 	},
 	{
 		message: "SampleBuilder should emit one packet, we had two packets but two with duplicate timestamps",
 		packets: []*rtp.Packet{
-			{SequenceNumber: 5000, Timestamp: 5, Payload: []byte{0x01}},
-			{SequenceNumber: 5001, Timestamp: 6, Payload: []byte{0x02}},
-			{SequenceNumber: 5002, Timestamp: 6, Payload: []byte{0x03}},
-			{SequenceNumber: 5003, Timestamp: 7, Payload: []byte{0x04}},
+			{SequenceNumber: 5000, Timestamp: 0x00050000, Payload: []byte{0x01}},
+			{SequenceNumber: 5001, Timestamp: 0x00060000, Payload: []byte{0x02}},
+			{SequenceNumber: 5002, Timestamp: 0x00060000, Payload: []byte{0x03}},
+			{SequenceNumber: 5003, Timestamp: 0x00070000, Payload: []byte{0x04}},
 		},
 		samples: []*media.RTCSample{
-			{Data: []byte{0x02, 0x03}, Samples: 1},
+			{Data: []byte{0x02, 0x03}, Duration: time.Second},
 		},
 		bufferSize: 50,
 	},
 	{
 		message: "SampleBuilder shouldn't emit a packet because we have a gap before a valid one",
 		packets: []*rtp.Packet{
-			{SequenceNumber: 5000, Timestamp: 5, Payload: []byte{0x01}},
-			{SequenceNumber: 5007, Timestamp: 6, Payload: []byte{0x02}},
-			{SequenceNumber: 5008, Timestamp: 7, Payload: []byte{0x03}},
+			{SequenceNumber: 5000, Timestamp: 0x00050000, Payload: []byte{0x01}},
+			{SequenceNumber: 5007, Timestamp: 0x00060000, Payload: []byte{0x02}},
+			{SequenceNumber: 5008, Timestamp: 0x00070000, Payload: []byte{0x03}},
 		},
 		samples:    []*media.RTCSample{},
 		bufferSize: 50,
@@ -69,18 +70,18 @@ var testCases = []sampleBuilderTest{
 	{
 		message: "SampleBuilder should emit multiple valid packets",
 		packets: []*rtp.Packet{
-			{SequenceNumber: 5000, Timestamp: 1, Payload: []byte{0x01}},
-			{SequenceNumber: 5001, Timestamp: 2, Payload: []byte{0x02}},
-			{SequenceNumber: 5002, Timestamp: 3, Payload: []byte{0x03}},
-			{SequenceNumber: 5003, Timestamp: 4, Payload: []byte{0x04}},
-			{SequenceNumber: 5004, Timestamp: 5, Payload: []byte{0x05}},
-			{SequenceNumber: 5005, Timestamp: 6, Payload: []byte{0x06}},
+			{SequenceNumber: 5000, Timestamp: 0x00010000, Payload: []byte{0x01}},
+			{SequenceNumber: 5001, Timestamp: 0x00020000, Payload: []byte{0x02}},
+			{SequenceNumber: 5002, Timestamp: 0x00030000, Payload: []byte{0x03}},
+			{SequenceNumber: 5003, Timestamp: 0x00040000, Payload: []byte{0x04}},
+			{SequenceNumber: 5004, Timestamp: 0x00050000, Payload: []byte{0x05}},
+			{SequenceNumber: 5005, Timestamp: 0x00060000, Payload: []byte{0x06}},
 		},
 		samples: []*media.RTCSample{
-			{Data: []byte{0x02}, Samples: 1},
-			{Data: []byte{0x03}, Samples: 1},
-			{Data: []byte{0x04}, Samples: 1},
-			{Data: []byte{0x05}, Samples: 1},
+			{Data: []byte{0x02}, Duration: time.Second},
+			{Data: []byte{0x03}, Duration: time.Second},
+			{Data: []byte{0x04}, Duration: time.Second},
+			{Data: []byte{0x05}, Duration: time.Second},
 		},
 		bufferSize: 50,
 	},

--- a/pkg/ntp/time.go
+++ b/pkg/ntp/time.go
@@ -1,0 +1,79 @@
+package ntp
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	epoch = time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
+	// CurrentEra is the most recent NTP era (RFC 5905 Section 6). It is used
+	// by conversions between Time64 and time.Time and may be overridden for
+	// testing or parsing historical timestamps.
+	CurrentEra = era(time.Now())
+)
+
+func era(t time.Time) int32 {
+	s := t.Sub(epoch) / time.Second
+	return int32(s >> 32)
+}
+
+// Time64 is a 64-bit unsigned fixed-point number (Q32.32) which encodes
+// the number of seconds since 0h UTC on 1 January 1900, with a precision
+// of about 200 picoseconds.
+//
+// The field will overflow in 2036 and every 136 years thereafter. For purposes
+// of conversion to time.Time, This implementation assumes that the time is
+// encoded in the most recent NTP era (RFC 5905 Section 6).
+type Time64 uint64
+
+// Duration returns the amount of time since the epoch represented by this timestamp.
+func (t Time64) Duration() time.Duration {
+	sec := time.Duration(t>>32) * time.Second
+	frac := time.Duration(t&0xffffffff) * time.Second >> 32
+	return sec + frac
+}
+
+// Time returns the Go Time represented by this timestamp.
+//
+// Conversions are made relative to the most recent NTP era's epoch (RFC 5905 Section 6).
+// The field overflows every 136 years, triggering a new era. This function may
+// return different results for the same timestamp around the start of a new era.
+func (t Time64) Time() time.Time {
+	eraOffset := time.Duration(CurrentEra) << 32 * time.Second
+	return epoch.Add(t.Duration()).Add(eraOffset)
+}
+
+// Time32 is an abbreviated timestamp formed using the middle 32 bits of a Time64
+// timestamp. It's a 32-bit unsigned fixed-point number (Q16.16) representing the
+// number of seconds since the NTP epoch. The high 16 bits are the integer part
+// and the low 16 bits are the fractional part.
+//
+// Because the timestamp overflows after around 18 hours it's only useful for
+// encoding relative durations between timestamps.
+type Time32 uint32
+
+// NewTime32 converts a time.Duration into a Time32
+//
+// Negative durations and durations greater than 65536s are invalid and will
+// produce an error.
+func NewTime32(d time.Duration) (Time32, error) {
+	if d < 0 {
+		return Time32(0), errors.New("duration must be positive")
+	}
+	if d > (1 << 16) {
+		return Time32(0), errors.New("duration must be less than d > (1<<16)")
+	}
+	sec := d / time.Second
+	frac := (d - sec*time.Second) << 16
+	frac = (frac + time.Second - 1) / time.Second
+	return Time32(sec<<32 | frac), nil
+}
+
+// Duration returns the amount of time since the epoch represented by this timestamp.
+func (t Time32) Duration() time.Duration {
+	t64 := uint64(t)
+	sec := (t64 >> 16) * uint64(time.Second)
+	frac := (t64 & 0xffff) * uint64(time.Second) >> 16
+	return time.Duration(sec + frac)
+}

--- a/pkg/ntp/time_test.go
+++ b/pkg/ntp/time_test.go
@@ -1,0 +1,50 @@
+package ntp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEra(t *testing.T) {
+	for _, test := range []struct {
+		Time time.Time
+		Want int32
+	}{
+		{
+			Time: time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC),
+			Want: 0,
+		},
+		{
+			Time: time.Date(1850, 1, 1, 0, 0, 0, 0, time.UTC),
+			Want: -1,
+		},
+		{
+			Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			Want: 0,
+		},
+		{
+			Time: time.Date(2040, 1, 1, 0, 0, 0, 0, time.UTC),
+			Want: 1,
+		},
+	} {
+		if got, want := era(test.Time), test.Want; got != want {
+			t.Fatalf("era(%v) = %v, want %v", test.Time, got, want)
+		}
+	}
+}
+
+func TestTime64(t *testing.T) {
+	for _, test := range []struct {
+		Time64 Time64
+		Want   time.Time
+	}{
+		{
+			Time64: Time64(0xDA8BD1fCDDDDA05A),
+			Want:   time.Date(2016, 3, 10, 10, 59, 8, 866663000, time.UTC),
+		},
+	} {
+		if got, want := test.Time64.Time(), test.Want; got != want {
+			t.Fatalf("Time() = %v, want %v", got, want)
+		}
+	}
+}

--- a/pkg/rtcp/reception_report.go
+++ b/pkg/rtcp/reception_report.go
@@ -1,6 +1,10 @@
 package rtcp
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	"github.com/pions/webrtc/pkg/ntp"
+)
 
 // A ReceptionReport block conveys statistics on the reception of RTP packets
 // from a single synchronization source.
@@ -27,7 +31,7 @@ type ReceptionReport struct {
 	// The middle 32 bits out of 64 in the NTP timestamp received as part of
 	// the most recent RTCP sender report (SR) packet from source SSRC. If no
 	// SR has been received yet, the field is set to zero.
-	LastSenderReport uint32
+	LastSenderReport ntp.Time32
 	// The delay, expressed in units of 1/65536 seconds, between receiving the
 	// last SR packet from source SSRC and sending this reception report block.
 	// If no SR packet has been received yet from SSRC, the field is set to zero.
@@ -81,7 +85,7 @@ func (r ReceptionReport) Marshal() ([]byte, error) {
 
 	binary.BigEndian.PutUint32(rawPacket[lastSeqOffset:], r.LastSequenceNumber)
 	binary.BigEndian.PutUint32(rawPacket[jitterOffset:], r.Jitter)
-	binary.BigEndian.PutUint32(rawPacket[lastSROffset:], r.LastSenderReport)
+	binary.BigEndian.PutUint32(rawPacket[lastSROffset:], uint32(r.LastSenderReport))
 	binary.BigEndian.PutUint32(rawPacket[delayOffset:], r.Delay)
 
 	return rawPacket, nil
@@ -119,7 +123,7 @@ func (r *ReceptionReport) Unmarshal(rawPacket []byte) error {
 
 	r.LastSequenceNumber = binary.BigEndian.Uint32(rawPacket[lastSeqOffset:])
 	r.Jitter = binary.BigEndian.Uint32(rawPacket[jitterOffset:])
-	r.LastSenderReport = binary.BigEndian.Uint32(rawPacket[lastSROffset:])
+	r.LastSenderReport = ntp.Time32(binary.BigEndian.Uint32(rawPacket[lastSROffset:]))
 	r.Delay = binary.BigEndian.Uint32(rawPacket[delayOffset:])
 
 	return nil

--- a/pkg/rtp/packet.go
+++ b/pkg/rtp/packet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/pions/webrtc/pkg/ntp"
 	"github.com/pkg/errors"
 )
 
@@ -18,7 +19,7 @@ type Packet struct {
 	PayloadOffset    int
 	PayloadType      uint8
 	SequenceNumber   uint16
-	Timestamp        uint32
+	Timestamp        ntp.Time32
 	SSRC             uint32
 	CSRC             []uint32
 	ExtensionProfile uint16
@@ -93,7 +94,7 @@ func (p *Packet) Unmarshal(rawPacket []byte) error {
 	p.PayloadType = rawPacket[1] & ptMask
 
 	p.SequenceNumber = binary.BigEndian.Uint16(rawPacket[seqNumOffset : seqNumOffset+seqNumLength])
-	p.Timestamp = binary.BigEndian.Uint32(rawPacket[timestampOffset : timestampOffset+timestampLength])
+	p.Timestamp = ntp.Time32(binary.BigEndian.Uint32(rawPacket[timestampOffset : timestampOffset+timestampLength]))
 	p.SSRC = binary.BigEndian.Uint32(rawPacket[ssrcOffset : ssrcOffset+ssrcLength])
 
 	currOffset := csrcOffset + (len(p.CSRC) * csrcLength)
@@ -169,7 +170,7 @@ func (p *Packet) Marshal() ([]byte, error) {
 	rawPacket[1] |= p.PayloadType
 
 	binary.BigEndian.PutUint16(rawPacket[seqNumOffset:], p.SequenceNumber)
-	binary.BigEndian.PutUint32(rawPacket[timestampOffset:], p.Timestamp)
+	binary.BigEndian.PutUint32(rawPacket[timestampOffset:], uint32(p.Timestamp))
 	binary.BigEndian.PutUint32(rawPacket[ssrcOffset:], p.SSRC)
 
 	for i, csrc := range p.CSRC {

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pions/webrtc/pkg/ice"
 	"github.com/pions/webrtc/pkg/logging"
 	"github.com/pions/webrtc/pkg/media"
+	"github.com/pions/webrtc/pkg/ntp"
 	"github.com/pions/webrtc/pkg/rtcerr"
 	"github.com/pions/webrtc/pkg/rtcp"
 	"github.com/pions/webrtc/pkg/rtp"
@@ -1566,7 +1567,11 @@ func (pc *RTCPeerConnection) newRTCTrack(payloadType uint8, ssrc uint32, id, lab
 				if !ok {
 					return
 				}
-				packets := packetizer.Packetize(in.Data, in.Samples)
+				dur, err := ntp.NewTime32(in.Duration)
+				if err != nil {
+					continue
+				}
+				packets := packetizer.Packetize(in.Data, dur)
 				for _, p := range packets {
 					pc.sendRTP(p)
 				}

--- a/rtcpeerconnection_media_test.go
+++ b/rtcpeerconnection_media_test.go
@@ -75,7 +75,7 @@ func TestRTCPeerConnection_Media_Sample(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
-			vp8Track.Samples <- media.RTCSample{Data: []byte{0x00}, Samples: 1}
+			vp8Track.Samples <- media.RTCSample{Data: []byte{0x00}, Duration: time.Millisecond}
 
 			select {
 			case <-awaitRTPRecv:


### PR DESCRIPTION
_This is a breaking API change. It's a work in progress, but I want to get it on the radar for 2.0. Let me know what you think._

Using a custom type rather than raw integers  makes it easier
to parse RTP and RTCP timestamps and convert them into Go types.
This will be useful for writing jitter buffers, track synchronization,
and statistics tabulation code.

Easy conversion from the Go time package also allows us to use
a time.Duration in the RTCSample struct. This makes it more difficult
to produce invalid packets with short timestamps while using
the SampleTrack interface.