### PR TITLE
Ignore case when parsing RTCIceProtocol

### DIFF
--- a/rtciceprotocol.go
+++ b/rtciceprotocol.go
@@ -1,6 +1,9 @@
 package webrtc
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // RTCIceProtocol indicates the transport protocol type that is used in the
 // ice.URL structure.
@@ -21,10 +24,10 @@ const (
 )
 
 func newRTCIceProtocol(raw string) (RTCIceProtocol, error) {
-	switch raw {
-	case rtcIceProtocolUDPStr:
+	switch {
+	case strings.EqualFold(rtcIceProtocolUDPStr, raw):
 		return RTCIceProtocolUDP, nil
-	case rtcIceProtocolTCPStr:
+	case strings.EqualFold(rtcIceProtocolTCPStr, raw):
 		return RTCIceProtocolTCP, nil
 	default:
 		return RTCIceProtocol(Unknown), fmt.Errorf("unknown protocol: %s", raw)

--- a/rtciceprotocol_test.go
+++ b/rtciceprotocol_test.go
@@ -15,6 +15,8 @@ func TestNewRTCIceProtocol(t *testing.T) {
 		{unknownStr, true, RTCIceProtocol(Unknown)},
 		{"udp", false, RTCIceProtocolUDP},
 		{"tcp", false, RTCIceProtocolTCP},
+		{"UDP", false, RTCIceProtocolUDP},
+		{"TCP", false, RTCIceProtocolTCP},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Before we would fail to parse RTCIceProtocol if it was upcased.

Relates to #289