### PR TITLE
Agent handles any inbound package (as opposed to STUN only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Tobias Fridén](https://github.com/tobiasfriden) *SRTP authentication verification*
 * [Yutaka Takeda](https://github.com/enobufs) *Fix ICE connection timeout*
+* [Hugo Arregui](https://github.com/hugoArregui) *Fix connection timeout*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -684,7 +684,7 @@ func (a *Agent) handleNewPeerReflexiveCandidate(local *Candidate, remote net.Add
 	return nil
 }
 
-// handleInbound processes traffic from a remote candidate
+// handleInbound processes STUN traffic from a remote candidate
 func (a *Agent) handleInbound(m *stun.Message, local *Candidate, remote net.Addr) {
 	iceLog.Tracef("inbound STUN from %s to %s", remote.String(), local.String())
 	remoteCandidate := a.findRemoteCandidate(local.NetworkType, remote)
@@ -708,6 +708,14 @@ func (a *Agent) handleInbound(m *stun.Message, local *Candidate, remote net.Addr
 		a.handleInboundControlling(m, local, remoteCandidate)
 	} else {
 		a.handleInboundControlled(m, local, remoteCandidate)
+	}
+}
+
+// noSTUNSeen processes non STUN traffic from a remote candidate
+func (a *Agent) noSTUNSeen(local *Candidate, remote net.Addr) {
+	remoteCandidate := a.findRemoteCandidate(local.NetworkType, remote)
+	if remoteCandidate != nil {
+		remoteCandidate.seen(false)
 	}
 }
 

--- a/pkg/ice/candidate.go
+++ b/pkg/ice/candidate.go
@@ -118,6 +118,13 @@ func (c *Candidate) recvLoop() {
 			}
 
 			continue
+		} else {
+			err := c.agent.run(func(agent *Agent) {
+				agent.noSTUNSeen(c, srcAddr)
+			})
+			if err != nil {
+				iceLog.Warnf("Failed to handle message: %v", err)
+			}
 		}
 
 		select {


### PR DESCRIPTION
This way, we update lastReceived properly, not just for STUN messages.

We are using lastReceived to check for a connection timeout (https://github.com/pions/webrtc/blob/master/pkg/ice/agent.go#L442) but the problem was we were not updating lastReceived for non STUN messages