### PR TITLE
Return error if AddIceCandidate is called but no remote description is set

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -71,4 +71,8 @@ var (
 
 	// ErrCodecNotFound is returned when a codec search to the Media Engine fails
 	ErrCodecNotFound = errors.New("Codec not found")
+
+	// ErrNoRemoteDescription indicates that an operation was rejected because
+	// the remote description is not set
+	ErrNoRemoteDescription = errors.New("remote description is not set")
 )

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -1063,6 +1063,10 @@ func (pc *RTCPeerConnection) RemoteDescription() *RTCSessionDescription {
 // to the existing set of candidates
 func (pc *RTCPeerConnection) AddIceCandidate(s string) error {
 	// TODO: AddIceCandidate should take RTCIceCandidateInit
+	if pc.CurrentRemoteDescription != nil {
+		return &rtcerr.InvalidStateError{Err: ErrNoRemoteDescription}
+	}
+
 	s = strings.TrimPrefix(s, "candidate:")
 
 	attribute := sdp.NewAttribute("candidate", s)


### PR DESCRIPTION
Return proper error and prevent nil pointer dereference