### PR TITLE
Fix inverted logic for AddIceCandidate check

### DIFF
--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -1063,7 +1063,7 @@ func (pc *RTCPeerConnection) RemoteDescription() *RTCSessionDescription {
 // to the existing set of candidates
 func (pc *RTCPeerConnection) AddIceCandidate(s string) error {
 	// TODO: AddIceCandidate should take RTCIceCandidateInit
-	if pc.CurrentRemoteDescription != nil {
+	if pc.RemoteDescription() == nil {
 		return &rtcerr.InvalidStateError{Err: ErrNoRemoteDescription}
 	}
 


### PR DESCRIPTION
References #372

The test for nil remote description is backwards, resulting
in errors being returned when there is a remote description
set.