### PR TITLE
[WIP] ORTC Media API Refinements

### DIFF
--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -3,7 +3,6 @@ package webrtc
 import (
 	"testing"
 
-	"github.com/pions/sdp/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,6 +29,6 @@ func TestCodecRegistration(t *testing.T) {
 		assert.Equal(t, f.e, err)
 
 	}
-	_, err := api.mediaEngine.getCodecSDP(sdp.Codec{PayloadType: invalidPT})
+	_, err := api.mediaEngine.getCodecSDP(RTPCodecParameters{PayloadType: invalidPT})
 	assert.Equal(t, err, ErrCodecNotFound)
 }

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -79,11 +79,15 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = signalPair(pcOffer, pcAnswer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
 			vp8Track.Samples <- media.Sample{Data: []byte{0x00}, Samples: 1}
-
 			select {
 			case <-awaitRTPRecv:
 				close(awaitRTPSend)
@@ -113,11 +117,6 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		<-vp8Track.RTCPPackets
 		close(awaitRTCPSenderRecv)
 	}()
-
-	err = signalPair(pcOffer, pcAnswer)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	<-awaitRTPRecv
 	<-awaitRTPSend

--- a/rtcpfeedback.go
+++ b/rtcpfeedback.go
@@ -1,0 +1,7 @@
+package webrtc
+
+// RTCPFeedback provides information on RTCP feedback messages.
+type RTCPFeedback struct {
+	Type      string // TODO: Enum
+	Parameter string // TODO: Enum
+}

--- a/rtcpparameters.go
+++ b/rtcpparameters.go
@@ -1,0 +1,6 @@
+package webrtc
+
+// RTCPParameters provides information on RTCP settings.
+type RTCPParameters struct {
+	SSRC uint32
+}

--- a/rtpcodecparameters.go
+++ b/rtpcodecparameters.go
@@ -1,0 +1,44 @@
+package webrtc
+
+import "fmt"
+
+// RTPCodecParameters provides information on codec settings.
+type RTPCodecParameters struct {
+	Name         string
+	MimeType     string
+	PayloadType  uint8
+	ClockRate    uint32
+	Maxptime     uint32
+	Ptime        uint32
+	Channels     uint32
+	RTCPFeedback []RTCPFeedback
+	Parameters   map[string]string
+}
+
+func (p RTPCodecParameters) String() string {
+	return fmt.Sprintf("%d %s/%d/%d", p.PayloadType, p.Name, p.ClockRate, p.Channels)
+}
+
+func (p RTPCodecParameters) equalFMTP(other string) (bool, error) {
+	b, err := sdpParseFmtpString(other)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse FMTP: %s: %v", other, err)
+	}
+
+	return cmpMapStringString(p.Parameters, b), nil
+}
+
+func cmpMapStringString(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		vb, ok := b[k]
+		if !ok || vb != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/rtpheaderextensionparameters.go
+++ b/rtpheaderextensionparameters.go
@@ -1,0 +1,9 @@
+package webrtc
+
+// RTPHeaderExtensionParameters dictionary enables a header extension
+// to be configured for use within an RTPSender or RTPReceiver.
+type RTPHeaderExtensionParameters struct {
+	ID        uint16
+	direction string
+	URI       string
+}

--- a/rtpparameters.go
+++ b/rtpparameters.go
@@ -1,0 +1,20 @@
+package webrtc
+
+import "fmt"
+
+// RTPParameters contains the RTP stack settings used by both senders and receivers.
+type RTPParameters struct {
+	Codecs           []RTPCodecParameters
+	HeaderExtensions []RTPHeaderExtensionParameters
+	RTCP             RTCPParameters
+}
+
+func (p RTPReceiveParameters) getCodecParameters(payloadType uint8) (RTPCodecParameters, error) {
+	for _, codec := range p.Codecs {
+		if codec.PayloadType == payloadType {
+			return codec, nil
+		}
+	}
+
+	return RTPCodecParameters{}, fmt.Errorf("payload type %d not found", payloadType)
+}

--- a/rtpreceiveparameters.go
+++ b/rtpreceiveparameters.go
@@ -2,5 +2,6 @@ package webrtc
 
 // RTPReceiveParameters contains the RTP stack settings used by receivers
 type RTPReceiveParameters struct {
-	encodings RTPDecodingParameters
+	RTPParameters
+	Encodings []RTPDecodingParameters
 }

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -1,8 +1,12 @@
 package webrtc
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/pions/rtcp"
 	"github.com/pions/rtp"
+	"github.com/pions/srtp"
 	"github.com/pions/webrtc/pkg/media"
 )
 
@@ -10,44 +14,52 @@ const rtpOutboundMTU = 1400
 
 // RTPSender allows an application to control how a given Track is encoded and transmitted to a remote peer
 type RTPSender struct {
+	lock sync.RWMutex
+
 	Track *Track
 
 	transport *DTLSTransport
+
+	// A reference to the associated api object
+	api *API
 }
 
 // NewRTPSender constructs a new RTPSender
-func NewRTPSender(track *Track, transport *DTLSTransport) *RTPSender {
-	r := &RTPSender{
+func (api *API) NewRTPSender(track *Track, transport *DTLSTransport) *RTPSender {
+	return &RTPSender{
 		Track:     track,
 		transport: transport,
+		api:       api,
 	}
-
-	r.Track.sampleInput = make(chan media.Sample, 15) // Is the buffering needed?
-	r.Track.rawInput = make(chan *rtp.Packet, 15)     // Is the buffering needed?
-	r.Track.rtcpInput = make(chan rtcp.Packet, 15)    // Is the buffering needed?
-
-	r.Track.Samples = r.Track.sampleInput
-	r.Track.RawRTP = r.Track.rawInput
-	r.Track.RTCPPackets = r.Track.rtcpInput
-
-	if r.Track.isRawRTP {
-		close(r.Track.Samples)
-	} else {
-		close(r.Track.RawRTP)
-	}
-
-	return r
 }
 
 // Send Attempts to set the parameters controlling the sending of media.
-func (r *RTPSender) Send(parameters RTPSendParameters) {
+func (r *RTPSender) Send(parameters RTPSendParameters) error {
 	if r.Track.isRawRTP {
 		go r.handleRawRTP(r.Track.rawInput)
 	} else {
 		go r.handleSampleRTP(r.Track.sampleInput)
 	}
 
-	go r.handleRTCP(r.transport, r.Track.rtcpInput)
+	dtls, err := r.Transport()
+	if err != nil {
+		return err
+	}
+
+	srtcpSession, err := dtls.getSrtcpSession()
+	if err != nil {
+		return err
+	}
+
+	ssrc := r.Track.SSRC
+	srtcpStream, err := srtcpSession.OpenReadStream(ssrc)
+	if err != nil {
+		return fmt.Errorf("failed to open RTCP ReadStream, RTCTrack done for: %v %d", err, ssrc)
+	}
+
+	go r.handleRTCP(srtcpStream, r.Track.rtcpInput)
+
+	return nil
 }
 
 // Stop irreversibly stops the RTPSender
@@ -68,7 +80,10 @@ func (r *RTPSender) handleRawRTP(rtpPackets chan *rtp.Packet) {
 			return
 		}
 
-		r.sendRTP(p)
+		err := r.sendRTP(p)
+		if err != nil {
+			pcLog.Warnf("failed to send RTP: %v", err)
+		}
 	}
 }
 
@@ -89,29 +104,33 @@ func (r *RTPSender) handleSampleRTP(rtpPackets chan media.Sample) {
 		}
 		packets := packetizer.Packetize(in.Data, in.Samples)
 		for _, p := range packets {
-			r.sendRTP(p)
+			err := r.sendRTP(p)
+			if err != nil {
+				pcLog.Warnf("failed to send RTP: %v", err)
+			}
 		}
 	}
 
 }
 
-func (r *RTPSender) handleRTCP(transport *DTLSTransport, rtcpPackets chan rtcp.Packet) {
-	srtcpSession, err := transport.getSRTCPSession()
-	if err != nil {
-		pcLog.Warnf("Failed to open SRTCPSession, Track done for: %v %d \n", err, r.Track.SSRC)
-		return
+// Transport returns the DTLSTransport instance over which
+// RTP is sent and received.
+func (r *RTPSender) Transport() (*DTLSTransport, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if r.transport == nil {
+		return nil, fmt.Errorf("the DTLS transport is not started")
 	}
 
-	readStream, err := srtcpSession.OpenReadStream(r.Track.SSRC)
-	if err != nil {
-		pcLog.Warnf("Failed to open RTCP ReadStream, Track done for: %v %d \n", err, r.Track.SSRC)
-		return
-	}
+	return r.transport, nil
+}
 
+func (r *RTPSender) handleRTCP(stream *srtp.ReadStreamSRTCP, rtcpPackets chan rtcp.Packet) {
 	var rtcpPacket rtcp.Packet
 	for {
 		rtcpBuf := make([]byte, receiveMTU)
-		i, err := readStream.Read(rtcpBuf)
+		i, err := stream.Read(rtcpBuf)
 		if err != nil {
 			pcLog.Warnf("Failed to read, Track done for: %v %d \n", err, r.Track.SSRC)
 			return
@@ -128,23 +147,27 @@ func (r *RTPSender) handleRTCP(transport *DTLSTransport, rtcpPackets chan rtcp.P
 		default:
 		}
 	}
-
 }
 
-func (r *RTPSender) sendRTP(packet *rtp.Packet) {
-	srtpSession, err := r.transport.getSRTPSession()
+func (r *RTPSender) sendRTP(packet *rtp.Packet) error {
+	dtls, err := r.Transport()
 	if err != nil {
-		pcLog.Warnf("SendRTP failed to open SrtpSession: %v", err)
-		return
+		return err
+	}
+
+	srtpSession, err := dtls.getSrtpSession()
+	if err != nil {
+		return err
 	}
 
 	writeStream, err := srtpSession.OpenWriteStream()
 	if err != nil {
-		pcLog.Warnf("SendRTP failed to open WriteStream: %v", err)
-		return
+		return fmt.Errorf("failed to open WriteStream: %v", err)
 	}
 
 	if _, err := writeStream.WriteRTP(&packet.Header, packet.Payload); err != nil {
-		pcLog.Warnf("SendRTP failed to write: %v", err)
+		return fmt.Errorf("failed to write: %v", err)
 	}
+
+	return nil
 }

--- a/rtptranceiver.go
+++ b/rtptranceiver.go
@@ -1,10 +1,12 @@
 package webrtc
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
-// RTPTransceiver represents a combination of an RTPSender and an RTPReceiver that share a common mid.
+// RTPTransceiver represents a combination of an RTCRtpSender and an RTCRtpReceiver that share a common mid.
 type RTPTransceiver struct {
 	Mid       string
 	Sender    *RTPSender
@@ -14,6 +16,11 @@ type RTPTransceiver struct {
 	// firedDirection   RTPTransceiverDirection
 	// receptive bool
 	stopped bool
+
+	remoteCapabilities     RTPParameters
+	recvDecodingParameters []RTPDecodingParameters
+
+	peerConnection *PeerConnection
 }
 
 func (t *RTPTransceiver) setSendingTrack(track *Track) error {
@@ -30,7 +37,36 @@ func (t *RTPTransceiver) setSendingTrack(track *Track) error {
 	return nil
 }
 
-// Stop irreversibly stops the RTPTransceiver
+func (t *RTPTransceiver) start() error {
+	// Start the sender
+	sender := t.Sender
+	if sender != nil {
+		sender.Send(RTPSendParameters{
+			encodings: RTPEncodingParameters{
+				RTPCodingParameters{SSRC: sender.Track.SSRC, PayloadType: sender.Track.PayloadType},
+			}})
+	}
+
+	// Start the receiver
+	receiver := t.Receiver
+	if receiver != nil {
+		params := RTPReceiveParameters{
+			RTPParameters: t.remoteCapabilities,
+			Encodings:     t.recvDecodingParameters,
+		}
+
+		err := receiver.Receive(params)
+		if err != nil {
+			return fmt.Errorf("failed to receive: %v", err)
+		}
+
+		t.peerConnection.onTrack(receiver.Track)
+	}
+
+	return nil
+}
+
+// Stop irreversibly stops the RTCRtpTransceiver
 func (t *RTPTransceiver) Stop() error {
 	if t.Sender != nil {
 		t.Sender.Stop()

--- a/sdputils.go
+++ b/sdputils.go
@@ -1,0 +1,329 @@
+package webrtc
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pions/sdp/v2"
+)
+
+// Port of the SDPUtils logic used in
+// https://github.com/webrtcHacks/adapter
+
+// sdpParseRTPDecodingParameters parses the SDP media section and returns
+// an array of RTPDecodingParameters.
+func sdpParseRTPDecodingParameters(d *sdp.MediaDescription) ([]RTPDecodingParameters, error) {
+	res := make([]RTPDecodingParameters, 0)
+
+	ssrcs := make([]sdpSSRCMedia, 0)
+	err := sdpMatchAttributePrefixFunc(d, sdp.AttrKeySSRC, "", func(a sdp.Attribute) error {
+		ssrc, pErr := sdpParseSSRCMedia(a)
+		if pErr != nil {
+			return pErr
+		}
+		// filter a=ssrc:... cname:, ignore PlanB-msid
+		if ssrc.Attribute == "cname" {
+			ssrcs = append(ssrcs, ssrc)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ssrcs: %v", err)
+	}
+
+	if len(ssrcs) == 0 {
+		return nil, errors.New("no ssrc found in media description")
+	}
+
+	primarySSRC := ssrcs[0].SSRC
+
+	res = append(res, RTPDecodingParameters{
+		RTPCodingParameters{
+			SSRC: primarySSRC,
+		},
+	})
+
+	return res, nil
+}
+
+// Parses the SDP media section and returns RTPParameters.
+func sdpParseRTPParameters(d *sdp.MediaDescription) (RTPParameters, error) {
+	res := RTPParameters{}
+
+	// Parse codecs
+	for _, format := range d.MediaName.Formats {
+		err := sdpMatchAttributePrefixFunc(d, "rtpmap", format+" ", sdpRTPCodecParser(d, &res))
+		if err != nil {
+			return RTPParameters{}, fmt.Errorf("failed to parse codec: %v", err)
+		}
+	}
+
+	// Parse header extensions
+	err := sdpMatchAttributePrefixFunc(d, "extmap", "", sdpExtmapParser(d, &res))
+	if err != nil {
+		return RTPParameters{}, fmt.Errorf("failed to parse header extensions: %v", err)
+	}
+
+	return res, nil
+}
+
+func sdpRTPCodecParser(d *sdp.MediaDescription, p *RTPParameters) sdpAttributeParser {
+	return func(a sdp.Attribute) error {
+		codec, err := sdpParseRtpMap(a)
+		if err != nil {
+			return err
+		}
+
+		prefix := fmt.Sprintf("%d ", codec.PayloadType)
+		err = sdpMatchAttributePrefixFunc(d, "fmtp", prefix, sdpRTPFmtpParser(d, &codec))
+		if err != nil {
+			return fmt.Errorf("failed to parse fmtp: %v", err)
+		}
+
+		prefix = fmt.Sprintf("%d ", codec.PayloadType)
+		err = sdpMatchAttributePrefixFunc(d, "rtcp-fb", prefix, sdpRtpRtcpFeedbackParser(d, &codec))
+		if err != nil {
+			return fmt.Errorf("failed to parse rtcp feedback: %v", err)
+		}
+
+		p.Codecs = append(p.Codecs, codec)
+
+		return nil
+	}
+}
+
+func sdpRTPFmtpParser(d *sdp.MediaDescription, p *RTPCodecParameters) sdpAttributeParser {
+	return func(a sdp.Attribute) error {
+		params, err := sdpParseFmtp(a)
+		if err != nil {
+			return err
+		}
+		p.Parameters = params
+
+		return nil
+	}
+}
+
+// Parses an ftmp line, returns dictionary. Sample input:
+// a=fmtp:96 vbr=on;cng=on
+// Also deals with vbr=on; cng=on
+func sdpParseFmtp(a sdp.Attribute) (map[string]string, error) {
+	sp := strings.Index(a.Value, " ")
+	if sp < 1 {
+		return nil, fmt.Errorf("attribute to short: %s", a.Value)
+	}
+
+	paramsStr := a.Value[sp+1:]
+	return sdpParseFmtpString(paramsStr)
+}
+
+// Parses an ftmp value, returns dictionary. Sample input:
+// vbr=on;cng=on
+func sdpParseFmtpString(paramsStr string) (map[string]string, error) {
+	res := make(map[string]string)
+
+	params := strings.Split(paramsStr, ";")
+	for _, param := range params {
+		if len(strings.TrimSpace(param)) == 0 {
+			continue
+		}
+		parts := strings.Split(param, "=")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid parameter: %s", param)
+		}
+		k := strings.TrimSpace(parts[0])
+		v := strings.TrimSpace(parts[1])
+		res[k] = v
+	}
+
+	return res, nil
+}
+
+func sdpRtpRtcpFeedbackParser(d *sdp.MediaDescription, p *RTPCodecParameters) sdpAttributeParser {
+	return func(a sdp.Attribute) error {
+		fb, err := sdpParseRtcpFeedback(a)
+		if err != nil {
+			return err
+		}
+		p.RTCPFeedback = append(p.RTCPFeedback, fb)
+
+		return nil
+	}
+}
+
+// Parses an rtcp-fb line, returns RTCPRtcpFeedback object. Sample input:
+// a=rtcp-fb:98 nack rpsi
+func sdpParseRtcpFeedback(a sdp.Attribute) (RTCPFeedback, error) {
+	sp := strings.Index(a.Value, " ")
+	if sp < 1 {
+		return RTCPFeedback{}, fmt.Errorf("rtcp-fb attribute to short: %s", a.Value)
+	}
+	fbStr := a.Value[sp+1:]
+	sp = strings.Index(fbStr, " ")
+
+	typ := fbStr
+	param := ""
+	if sp > 0 {
+		typ = fbStr[:sp]
+		param = fbStr[sp+1:]
+	}
+
+	return RTCPFeedback{
+		Type:      typ,
+		Parameter: param,
+	}, nil
+}
+
+func sdpExtmapParser(d *sdp.MediaDescription, p *RTPParameters) sdpAttributeParser {
+	return func(a sdp.Attribute) error {
+		ext, err := sdpParseExtmap(a)
+		if err != nil {
+			return err
+		}
+		p.HeaderExtensions = append(p.HeaderExtensions, ext)
+
+		return nil
+	}
+}
+
+// Parses an a=extmap line (headerextension from RFC 5285). Sample input:
+// a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
+// a=extmap:2/sendonly urn:ietf:params:rtp-hdrext:toffset
+func sdpParseExtmap(a sdp.Attribute) (RTPHeaderExtensionParameters, error) {
+	sp := strings.Index(a.Value, " ")
+	if sp < 1 {
+		return RTPHeaderExtensionParameters{}, fmt.Errorf("extmap attribute to short: %s", a.Value)
+	}
+
+	idParts := strings.Split(a.Value[:sp], "/")
+
+	idStr := idParts[0]
+	id, err := strconv.ParseUint(idStr, 10, 16)
+	if err != nil {
+		return RTPHeaderExtensionParameters{}, fmt.Errorf("invalid id: %s", idStr)
+	}
+
+	direction := "sendrecv"
+	if len(idParts) > 1 {
+		direction = idParts[1]
+	}
+
+	uri := a.Value[sp+1:]
+
+	return RTPHeaderExtensionParameters{
+		ID:        uint16(id),
+		direction: direction,
+		URI:       uri,
+	}, nil
+}
+
+// Parses an rtpmap line, returns RTPCoddecParameters. Sample input:
+// a=rtpmap:109 opus/48000/2
+func sdpParseRtpMap(a sdp.Attribute) (RTPCodecParameters, error) {
+	sp := strings.Index(a.Value, " ")
+	if sp < 1 {
+		return RTPCodecParameters{}, fmt.Errorf("rtpmap attribute to short: %s", a.Value)
+	}
+	payloadTypeStr := a.Value[:sp]
+	payloadTypeRaw, err := strconv.ParseUint(payloadTypeStr, 10, 8)
+	if err != nil {
+		return RTPCodecParameters{}, fmt.Errorf("invalid payload type: %s", payloadTypeStr)
+	}
+
+	codecStr := a.Value[sp+1:]
+	parts := strings.Split(codecStr, "/")
+	if len(parts) < 2 {
+		return RTPCodecParameters{}, fmt.Errorf("invalid codec: %s", codecStr)
+	}
+	name := parts[0]
+
+	clockrateStr := parts[1]
+	clockrate, err := strconv.ParseUint(clockrateStr, 10, 32)
+	if err != nil {
+		return RTPCodecParameters{}, fmt.Errorf("invalid clockrate: %s", clockrateStr)
+	}
+
+	channels := uint64(0)
+	if len(parts) == 3 {
+		channelsStr := parts[2]
+		channels, err = strconv.ParseUint(channelsStr, 10, 32)
+		if err != nil {
+			return RTPCodecParameters{}, fmt.Errorf("invalid channels: %s", channelsStr)
+		}
+	}
+
+	return RTPCodecParameters{
+		Name:        name,
+		PayloadType: uint8(payloadTypeRaw),
+		ClockRate:   uint32(clockrate),
+		Channels:    uint32(channels),
+	}, nil
+}
+
+// Generic: could be moved to package SDP
+
+// sdpSSRCMedia represents a an RFC 5576 ssrc media attribute.
+type sdpSSRCMedia struct {
+	SSRC      uint32
+	Attribute string
+	Value     string
+}
+
+// Parses an RFC 5576 ssrc media attribute. Sample input:
+// a=ssrc:<ssrc-id> <attribute>
+// a=ssrc:<ssrc-id> <attribute>:<value>
+func sdpParseSSRCMedia(a sdp.Attribute) (sdpSSRCMedia, error) {
+	sp := strings.Index(a.Value, " ")
+	if sp < 1 {
+		return sdpSSRCMedia{}, fmt.Errorf("ssrc media attribute to short: %s", a.Value)
+	}
+	ssrcStr := a.Value[:sp]
+	ssrc, err := strconv.ParseUint(ssrcStr, 10, 32)
+	if err != nil {
+		return sdpSSRCMedia{}, fmt.Errorf("failed to parse ssrc: %s", ssrcStr)
+	}
+	parts := strings.Split(a.Value[sp+1:], ":")
+	attribute := parts[0]
+	value := ""
+	if len(parts) > 1 {
+		value = parts[1]
+	}
+
+	return sdpSSRCMedia{
+		SSRC:      uint32(ssrc),
+		Attribute: attribute,
+		Value:     value,
+	}, nil
+}
+
+type sdpAttributeParser func(sdp.Attribute) error
+
+func sdpMatchAttributePrefixFunc(d *sdp.MediaDescription, key, prefix string, p sdpAttributeParser) error {
+	for _, a := range d.Attributes {
+		if a.Key != key || !strings.HasPrefix(a.Value, prefix) {
+			continue
+		}
+
+		err := p(a)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sdpFindAttributePrefix(d *sdp.MediaDescription, key, prefix string) (sdp.Attribute, error) {
+	for _, a := range d.Attributes {
+		if a.Key != key || !strings.HasPrefix(a.Value, prefix) {
+			continue
+		}
+
+		return a, nil
+	}
+
+	return sdp.Attribute{}, errors.New("attribute not found")
+}

--- a/sdputils_test.go
+++ b/sdputils_test.go
@@ -1,0 +1,220 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/pions/sdp/v2"
+)
+
+func TestParseRtpDecodingParameters_Success(t *testing.T) {
+	tt := []struct {
+		in       *sdp.MediaDescription
+		expected []RTPDecodingParameters
+	}{
+		{
+			in: &sdp.MediaDescription{
+				Attributes: []sdp.Attribute{
+					{Key: "ssrc", Value: "2520107483 cname:{c830ce58-b0d6-4f95-bb9f-8722bb1eba28}"},
+					{Key: "ssrc", Value: "2520107483 bla:{c830ce58-b0d6-4f95-bb9f-8722bb1eba28}"},
+				},
+			},
+			expected: []RTPDecodingParameters{
+				{RTPCodingParameters{SSRC: 2520107483}},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		res, err := sdpParseRTPDecodingParameters(tc.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res) != len(tc.expected) {
+			t.Errorf("wrong number of parameters: got %d expected %d", len(res), len(tc.expected))
+		}
+		for i, a := range res {
+			e := tc.expected[i]
+			if a.SSRC != e.SSRC {
+				t.Errorf("wrong ssrc: got %d expected %d", a.SSRC, e.SSRC)
+			}
+		}
+	}
+}
+
+func TestParseRtpParameters_Success(t *testing.T) {
+	tt := []struct {
+		in       *sdp.MediaDescription
+		expected RTPParameters
+	}{
+		{
+			in: &sdp.MediaDescription{
+				MediaName: sdp.MediaName{
+					Formats: []string{"120", "109"},
+				},
+				Attributes: []sdp.Attribute{
+					{Key: "fmtp", Value: "120 max-fs=12288;max-fr=60"},
+					{Key: "rtcp-fb", Value: "120 nack"},
+					{Key: "rtcp-fb", Value: "tcp-fb:120 nack pli"},
+					{Key: "rtpmap", Value: "120 VP8/90000"},
+					{Key: "fmtp", Value: "109 maxplaybackrate=48000;stereo=1;useinbandfec=1"},
+					{Key: "rtpmap", Value: "109 opus/48000/2"},
+					{Key: "extmap", Value: "1 urn:ietf:params:rtp-hdrext:ssrc-audio-level"},
+					{Key: "extmap", Value: "2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level"},
+				},
+			},
+			expected: RTPParameters{
+				Codecs: []RTPCodecParameters{
+					{
+						Name:        "VP8",
+						PayloadType: 120,
+						ClockRate:   90000,
+						Channels:    0,
+						RTCPFeedback: []RTCPFeedback{
+							{
+								Type: "nack",
+							},
+							{
+								Type:      "nack",
+								Parameter: "pli",
+							},
+						},
+						Parameters: map[string]string{
+							"max-fs": "12288",
+							"max-fr": "60",
+						},
+					},
+					{
+						Name:        "opus",
+						PayloadType: 109,
+						ClockRate:   48000,
+						Channels:    2,
+						Parameters: map[string]string{
+							"maxplaybackrate": "48000",
+							"stereo":          "1",
+							"useinbandfec":    "1",
+						},
+					},
+				},
+				HeaderExtensions: []RTPHeaderExtensionParameters{
+					{
+						ID:        1,
+						direction: "sendrecv",
+						URI:       "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+					}, {
+						ID:        2,
+						direction: "recvonly",
+						URI:       "urn:ietf:params:rtp-hdrext:csrc-audio-level",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		res, err := sdpParseRTPParameters(tc.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(res.Codecs) != len(tc.expected.Codecs) {
+			t.Errorf("wrong number of codecs: got %d expected %d", len(res.Codecs), len(tc.expected.Codecs))
+		}
+
+		for i, a := range res.Codecs {
+			e := tc.expected.Codecs[i]
+			if a.Name != e.Name {
+				t.Errorf("wrong name: got %s expected %s", a.Name, e.Name)
+			}
+			if a.PayloadType != e.PayloadType {
+				t.Errorf("wrong payload type: got %d expected %d", a.PayloadType, e.PayloadType)
+			}
+			if a.ClockRate != e.ClockRate {
+				t.Errorf("wrong clock rate: got %d expected %d", a.ClockRate, e.ClockRate)
+			}
+			if a.Channels != e.Channels {
+				t.Errorf("wrong channels: got %d expected %d", a.Channels, e.Channels)
+			}
+
+			if len(a.RTCPFeedback) != len(e.RTCPFeedback) {
+				t.Errorf("wrong number of feedbacks: got %d expected %d", len(a.RTCPFeedback), len(e.RTCPFeedback))
+			}
+
+			for j, fba := range a.RTCPFeedback {
+				fbe := e.RTCPFeedback[j]
+				if fba.Type != fbe.Type {
+					t.Errorf("wrong type: got %s expected %s", fba.Type, fbe.Type)
+				}
+				if fba.Parameter != fbe.Parameter {
+					t.Errorf("wrong parameter: got %s expected %s", fba.Parameter, fbe.Parameter)
+				}
+			}
+
+			if len(a.Parameters) != len(e.Parameters) {
+				t.Errorf("wrong number of parameters: got %d expected %d", len(a.Parameters), len(e.Parameters))
+			}
+
+			for ka, pa := range a.Parameters {
+				pe, ok := e.Parameters[ka]
+				if !ok {
+					t.Errorf("parameter %s should not exist", ka)
+				}
+				if pa != pe {
+					t.Errorf("wrong parameter: got %s expected %s", pa, pe)
+				}
+			}
+		}
+
+		if len(res.HeaderExtensions) != len(tc.expected.HeaderExtensions) {
+			t.Errorf("wrong number of HeaderExtensions: got %d expected %d", len(res.HeaderExtensions), len(tc.expected.HeaderExtensions))
+		}
+
+		for i, a := range res.HeaderExtensions {
+			e := tc.expected.HeaderExtensions[i]
+			if a.ID != e.ID {
+				t.Errorf("wrong ID: got %d expected %d", a.ID, e.ID)
+			}
+			if a.direction != e.direction {
+				t.Errorf("wrong direction: got %s expected %s", a.direction, e.direction)
+			}
+			if a.URI != e.URI {
+				t.Errorf("wrong URI: got %s expected %s", a.URI, e.URI)
+			}
+
+		}
+	}
+}
+
+func TestParseSsrcMedia_Success(t *testing.T) {
+	tt := []struct {
+		in       sdp.Attribute
+		expected sdpSSRCMedia
+	}{
+		{
+			in: sdp.Attribute{
+				Key:   "ssrc",
+				Value: "3735928559 cname:something",
+			},
+			expected: sdpSSRCMedia{
+				SSRC:      3735928559,
+				Attribute: "cname",
+				Value:     "something",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		res, err := sdpParseSSRCMedia(tc.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.SSRC != tc.expected.SSRC {
+			t.Errorf("wrong ssrc: got %d expected %d", res.SSRC, tc.expected.SSRC)
+		}
+		if res.Attribute != tc.expected.Attribute {
+			t.Errorf("wrong attribute: got %s expected %s", res.Attribute, tc.expected.Attribute)
+		}
+		if res.Value != tc.expected.Value {
+			t.Errorf("wrong value: got %s expected %s", res.Value, tc.expected.Value)
+		}
+	}
+}


### PR DESCRIPTION
Goals:
- Split SDP parsing from network setup, based on [webrtcHacks/adapter](github.com/webrtcHacks/adapter).
- Move SRTP specific logic to SRTP package.
- Move ORTC Media API constructors to the API object.
- Minor API cleanup

TODO:
- [ ] Fix tests
- [ ] Update go.mod for DTLS & SRTP dependencies.