### PR TITLE
RTCRtpReceiver now properly tears down

### DIFF
--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -1048,30 +1048,40 @@ func (pc *RTCPeerConnection) AddIceCandidate(s string) error {
 // ------------------------------------------------------------------------
 
 // GetSenders returns the RTCRtpSender that are currently attached to this RTCPeerConnection
-func (pc *RTCPeerConnection) GetSenders() []RTCRtpSender {
-	result := make([]RTCRtpSender, len(pc.rtpTransceivers))
+func (pc *RTCPeerConnection) GetSenders() []*RTCRtpSender {
+	pc.Lock()
+	defer pc.Unlock()
+
+	result := make([]*RTCRtpSender, len(pc.rtpTransceivers))
 	for i, tranceiver := range pc.rtpTransceivers {
-		result[i] = *tranceiver.Sender
+		if tranceiver.Sender != nil {
+			result[i] = tranceiver.Sender
+		}
 	}
 	return result
 }
 
 // GetReceivers returns the RTCRtpReceivers that are currently attached to this RTCPeerConnection
-func (pc *RTCPeerConnection) GetReceivers() []RTCRtpReceiver {
-	result := make([]RTCRtpReceiver, len(pc.rtpTransceivers))
+func (pc *RTCPeerConnection) GetReceivers() []*RTCRtpReceiver {
+	pc.Lock()
+	defer pc.Unlock()
+
+	result := make([]*RTCRtpReceiver, len(pc.rtpTransceivers))
 	for i, tranceiver := range pc.rtpTransceivers {
-		result[i] = *tranceiver.Receiver
+		if tranceiver.Receiver != nil {
+			result[i] = tranceiver.Receiver
+
+		}
 	}
 	return result
 }
 
 // GetTransceivers returns the RTCRtpTransceiver that are currently attached to this RTCPeerConnection
-func (pc *RTCPeerConnection) GetTransceivers() []RTCRtpTransceiver {
-	result := make([]RTCRtpTransceiver, len(pc.rtpTransceivers))
-	for i, tranceiver := range pc.rtpTransceivers {
-		result[i] = *tranceiver
-	}
-	return result
+func (pc *RTCPeerConnection) GetTransceivers() []*RTCRtpTransceiver {
+	pc.Lock()
+	defer pc.Unlock()
+
+	return pc.rtpTransceivers
 }
 
 // AddTrack adds a RTCTrack to the RTCPeerConnection

--- a/rtcrtptranceiver.go
+++ b/rtcrtptranceiver.go
@@ -36,7 +36,9 @@ func (t *RTCRtpTransceiver) Stop() error {
 		t.Sender.Stop()
 	}
 	if t.Receiver != nil {
-		t.Receiver.Stop()
+		if err := t.Receiver.Stop(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
RTCRtpReceiver would leak routines and block if the ReadStream hadn't
given us a packet yet

Closes #387

Co-authored-by: rob-deutsch <robzyb+altgithub@gmail.com>