### PR TITLE
Fixed minor pipeline/element memory leak in examples/util

### DIFF
--- a/examples/util/gstreamer-sink/gst.c
+++ b/examples/util/gstreamer-sink/gst.c
@@ -57,5 +57,6 @@ void gstreamer_receive_push_buffer(GstElement *pipeline, void *buffer, int len) 
     gpointer p = g_memdup(buffer, len);
     GstBuffer *buffer = gst_buffer_new_wrapped(p, len);
     gst_app_src_push_buffer(GST_APP_SRC(src), buffer);
+    gst_object_unref(src);
   }
 }

--- a/examples/util/gstreamer-src/gst.c
+++ b/examples/util/gstreamer-src/gst.c
@@ -76,6 +76,7 @@ void gstreamer_send_start_pipeline(GstElement *pipeline, int pipelineId) {
   GstElement *appsink = gst_bin_get_by_name(GST_BIN(pipeline), "appsink");
   g_object_set(appsink, "emit-signals", TRUE, NULL);
   g_signal_connect(appsink, "new-sample", G_CALLBACK(gstreamer_send_new_sample_handler), s);
+  gst_object_unref(appsink);
 
   gst_element_set_state(pipeline, GST_STATE_PLAYING);
 }


### PR DESCRIPTION
When an element is selected by `gst_bin_get_by_name` we need to make sure that we also `gst_object_unref` it.

Fixes #394 