### PR TITLE
Stop Create(Offer/Answer) from setting localDesc

### DIFF
--- a/api.go
+++ b/api.go
@@ -89,8 +89,8 @@ func RegisterDefaultCodecs() {
 
 // PeerConnection API
 
-// New using the default API.
+// NewRTCPeerConnection using the default API.
 // See API.NewRTCPeerConnection for details.
-func New(configuration RTCConfiguration) (*RTCPeerConnection, error) {
+func NewRTCPeerConnection(configuration RTCConfiguration) (*RTCPeerConnection, error) {
 	return defaultAPI.NewRTCPeerConnection(configuration)
 }

--- a/examples/data-channels-close/main.go
+++ b/examples/data-channels-close/main.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -90,8 +90,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/examples/data-channels-create/main.go
+++ b/examples/data-channels-create/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Create a datachannel with label 'data'
@@ -63,6 +63,10 @@ func main() {
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(offer)
 	util.Check(err)
 
 	// Output the offer in base64 so we can paste it in browser

--- a/examples/data-channels-detach-create/main.go
+++ b/examples/data-channels-detach-create/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Create a datachannel with label 'data'
@@ -60,6 +60,10 @@ func main() {
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(offer)
 	util.Check(err)
 
 	// Output the offer in base64 so we can paste it in browser

--- a/examples/data-channels-detach/main.go
+++ b/examples/data-channels-detach/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -67,8 +67,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/examples/data-channels/main.go
+++ b/examples/data-channels/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -70,8 +70,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create an answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set a handler for when a new remote track starts, this handler creates a gstreamer pipeline
@@ -70,8 +70,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create an answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/examples/gstreamer-send-offer/main.go
+++ b/examples/gstreamer-send-offer/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -49,6 +49,10 @@ func main() {
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(offer)
 	util.Check(err)
 
 	// Output the offer in base64 so we can paste it in browser

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -60,8 +60,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create an answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
@@ -105,6 +105,9 @@ func main() {
 		util.Check(err)
 
 		answer, err := peerConnection.CreateAnswer(nil)
+		util.Check(err)
+
+		err = peerConnection.SetLocalDescription(answer)
 		util.Check(err)
 
 		// now we start

--- a/examples/janus-gateway/video-room/main.go
+++ b/examples/janus-gateway/video-room/main.go
@@ -7,7 +7,7 @@ import (
 	janus "github.com/notedit/janus-go"
 	"github.com/pions/webrtc"
 	"github.com/pions/webrtc/examples/util"
-	"github.com/pions/webrtc/examples/util/gstreamer-src"
+	gst "github.com/pions/webrtc/examples/util/gstreamer-src"
 	"github.com/pions/webrtc/pkg/ice"
 )
 
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	peerConnection.OnICEConnectionStateChange(func(connectionState ice.ConnectionState) {
@@ -69,6 +69,9 @@ func main() {
 	util.Check(err)
 
 	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	err = peerConnection.SetLocalDescription(offer)
 	util.Check(err)
 
 	gateway, err := janus.Connect("ws://localhost:8188/janus")

--- a/examples/pion-to-pion/answer/main.go
+++ b/examples/pion-to-pion/answer/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set the handler for ICE connection state
@@ -77,8 +77,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Send the answer

--- a/examples/pion-to-pion/offer/main.go
+++ b/examples/pion-to-pion/offer/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Create a datachannel with label 'data'
@@ -70,6 +70,10 @@ func main() {
 
 	// Create an offer to send to the browser
 	offer, err := peerConnection.CreateOffer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(offer)
 	util.Check(err)
 
 	// Exchange the offer for the answer

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.New(config)
+	peerConnection, err := webrtc.NewRTCPeerConnection(config)
 	util.Check(err)
 
 	// Set a handler for when a new remote track starts, this handler saves buffers to disk as
@@ -73,8 +73,12 @@ func main() {
 	err = peerConnection.SetRemoteDescription(offer)
 	util.Check(err)
 
-	// Sets the LocalDescription, and starts our UDP listeners
+	// Create answer
 	answer, err := peerConnection.CreateAnswer(nil)
+	util.Check(err)
+
+	// Sets the LocalDescription, and starts our UDP listeners
+	err = peerConnection.SetLocalDescription(answer)
 	util.Check(err)
 
 	// Output the answer in base64 so we can paste it in browser

--- a/rtcpeerconnection.go
+++ b/rtcpeerconnection.go
@@ -457,12 +457,6 @@ func (pc *RTCPeerConnection) CreateOffer(options *RTCOfferOptions) (RTCSessionDe
 		parsed: d,
 	}
 	pc.lastOffer = desc.Sdp
-
-	// FIXME: This doesn't follow the JS API spec, but removing it
-	// would mean our examples and existing code have to change
-	if err := pc.SetLocalDescription(desc); err != nil {
-		return RTCSessionDescription{}, err
-	}
 	return desc, nil
 }
 
@@ -567,12 +561,6 @@ func (pc *RTCPeerConnection) CreateAnswer(options *RTCAnswerOptions) (RTCSession
 		parsed: d,
 	}
 	pc.lastAnswer = desc.Sdp
-
-	// FIXME: This doesn't follow the JS API spec, but removing it
-	// would mean our examples and existing code have to change
-	if err := pc.SetLocalDescription(desc); err != nil {
-		return RTCSessionDescription{}, err
-	}
 	return desc, nil
 }
 

--- a/rtcpeerconnection_test.go
+++ b/rtcpeerconnection_test.go
@@ -37,6 +37,10 @@ func signalPair(pcOffer *RTCPeerConnection, pcAnswer *RTCPeerConnection) error {
 		return err
 	}
 
+	if err = pcOffer.SetLocalDescription(offer); err != nil {
+		return err
+	}
+
 	err = pcAnswer.SetRemoteDescription(offer)
 	if err != nil {
 		return err
@@ -44,6 +48,10 @@ func signalPair(pcOffer *RTCPeerConnection, pcAnswer *RTCPeerConnection) error {
 
 	answer, err := pcAnswer.CreateAnswer(nil)
 	if err != nil {
+		return err
+	}
+
+	if err = pcAnswer.SetLocalDescription(answer); err != nil {
 		return err
 	}
 
@@ -355,6 +363,9 @@ func TestCreateOfferAnswer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Create Offer: got error: %v", err)
 	}
+	if err = offerPeerConn.SetLocalDescription(offer); err != nil {
+		t.Errorf("SetLocalDescription: got error: %v", err)
+	}
 	answerPeerConn, err := api.NewRTCPeerConnection(RTCConfiguration{})
 	if err != nil {
 		t.Errorf("New RTCPeerConnection: got error: %v", err)
@@ -366,6 +377,9 @@ func TestCreateOfferAnswer(t *testing.T) {
 	answer, err := answerPeerConn.CreateAnswer(nil)
 	if err != nil {
 		t.Errorf("Create Answer: got error: %v", err)
+	}
+	if err = answerPeerConn.SetLocalDescription(answer); err != nil {
+		t.Errorf("SetLocalDescription: got error: %v", err)
 	}
 	err = offerPeerConn.SetRemoteDescription(answer)
 	if err != nil {


### PR DESCRIPTION
This deviates from the WebRTC spec, so we need to fix it. This is a
massively breaking change, so we need to figure out the best way to help
users with this.

I also renamed our RTCPeerConnection constructor. The hope is that
people will refer to the examples/backlog and see what changed.

Resolves #309

-----

I added all the devs as a heads up, if you think there is a better way we can handle this I am all ears!