### PR TITLE
Gstreamer-receive reserves main thread for Glib loop

### DIFF
--- a/examples/util/gstreamer-sink/gst.go
+++ b/examples/util/gstreamer-sink/gst.go
@@ -13,8 +13,12 @@ import (
 	"github.com/pions/webrtc"
 )
 
-func init() {
-	go C.gstreamer_receive_start_mainloop()
+// StartMainLoop starts GLib's main loop
+// It needs to be called from the process' main thread
+// Because many gstreamer plugins require access to the main thread
+// See: https://golang.org/pkg/runtime/#LockOSThread
+func StartMainLoop() {
+	C.gstreamer_receive_start_mainloop()
 }
 
 // Pipeline is a wrapper for a GStreamer Pipeline


### PR DESCRIPTION
The Glib loop is run in the main thread (in the OS point of view)

This is a simpler solution than [Russ Cox's solution](https://groups.google.com/forum/#!msg/golang-nuts/IiWZ2hUuLDA/SNKYYZBelsYJ) because of the simpler nature of gstreamer-receive.