### PR TITLE
Enable gocritic and fix reported errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   disable:
     - maligned
     - lll
-    - gocritic
     - gochecknoinits
     - gochecknoglobals
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Hugo Arregui](https://github.com/hugoArregui) *Fix connection timeout*
 * [Rob Deutsch](https://github.com/rob-deutsch) *RTPReceiver graceful shutdown*
 * [Jin Lei](https://github.com/jinleileiking) - *SFU example use http*
+* [Will Watson](https://github.com/wwatson) - *Enable gocritic*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -162,7 +162,7 @@ func TestDataChannel_MessagesAreOrdered(t *testing.T) {
 
 	max := 512
 	out := make(chan int)
-	inner := func(p sugar.Payload) {
+	inner := func(payload sugar.Payload) {
 		// randomly sleep
 		// NB: The big.Int/crypto.Rand is overkill but makes the linter happy
 		randInt, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
@@ -170,8 +170,8 @@ func TestDataChannel_MessagesAreOrdered(t *testing.T) {
 			t.Fatalf("Failed to get random sleep duration: %s", err)
 		}
 		time.Sleep(time.Duration(randInt.Int64()) * time.Microsecond)
-		switch p := p.(type) {
-		case *sugar.PayloadBinary:
+		p, ok := payload.(*sugar.PayloadBinary)
+		if ok {
 			s, _ := binary.Varint(p.Data)
 			out <- int(s)
 		}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -414,11 +414,12 @@ func (pc *PeerConnection) GetConfiguration() Configuration {
 // CreateOffer starts the PeerConnection and generates the localDescription
 func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription, error) {
 	useIdentity := pc.idpLoginURL != nil
-	if options != nil {
+	switch {
+	case options != nil:
 		return SessionDescription{}, errors.Errorf("TODO handle options")
-	} else if useIdentity {
+	case useIdentity:
 		return SessionDescription{}, errors.Errorf("TODO handle identity provider")
-	} else if pc.isClosed {
+	case pc.isClosed:
 		return SessionDescription{}, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
 	}
 
@@ -497,11 +498,12 @@ func (pc *PeerConnection) createDTLSTransport() (*DTLSTransport, error) {
 // CreateAnswer starts the PeerConnection and generates the localDescription
 func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescription, error) {
 	useIdentity := pc.idpLoginURL != nil
-	if options != nil {
+	switch {
+	case options != nil:
 		return SessionDescription{}, errors.Errorf("TODO handle options")
-	} else if useIdentity {
+	case useIdentity:
 		return SessionDescription{}, errors.Errorf("TODO handle identity provider")
-	} else if pc.isClosed {
+	case pc.isClosed:
 		return SessionDescription{}, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
 	}
 
@@ -524,13 +526,14 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 		var peerDirection RTPTransceiverDirection
 		midValue := ""
 		for _, a := range remoteMedia.Attributes {
-			if strings.HasPrefix(*a.String(), "mid") {
+			switch {
+			case strings.HasPrefix(*a.String(), "mid"):
 				midValue = (*a.String())[len("mid:"):]
-			} else if strings.HasPrefix(*a.String(), "sendrecv") {
+			case strings.HasPrefix(*a.String(), "sendrecv"):
 				peerDirection = RTPTransceiverDirectionSendrecv
-			} else if strings.HasPrefix(*a.String(), "sendonly") {
+			case strings.HasPrefix(*a.String(), "sendonly"):
 				peerDirection = RTPTransceiverDirectionSendonly
-			} else if strings.HasPrefix(*a.String(), "recvonly") {
+			case strings.HasPrefix(*a.String(), "recvonly"):
 				peerDirection = RTPTransceiverDirectionRecvonly
 			}
 		}
@@ -539,15 +542,16 @@ func (pc *PeerConnection) CreateAnswer(options *AnswerOptions) (SessionDescripti
 			bundleValue += " " + midValue
 		}
 
-		if strings.HasPrefix(*remoteMedia.MediaName.String(), "audio") {
+		switch {
+		case strings.HasPrefix(*remoteMedia.MediaName.String(), "audio"):
 			if pc.addRTPMediaSection(d, RTPCodecTypeAudio, midValue, iceParams, peerDirection, candidates, sdp.ConnectionRoleActive) {
 				appendBundle()
 			}
-		} else if strings.HasPrefix(*remoteMedia.MediaName.String(), "video") {
+		case strings.HasPrefix(*remoteMedia.MediaName.String(), "video"):
 			if pc.addRTPMediaSection(d, RTPCodecTypeVideo, midValue, iceParams, peerDirection, candidates, sdp.ConnectionRoleActive) {
 				appendBundle()
 			}
-		} else if strings.HasPrefix(*remoteMedia.MediaName.String(), "application") {
+		case strings.HasPrefix(*remoteMedia.MediaName.String(), "application"):
 			pc.addDataMediaSection(d, midValue, iceParams, candidates, sdp.ConnectionRoleActive)
 			appendBundle()
 		}
@@ -730,7 +734,8 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 
 	for _, m := range pc.RemoteDescription().parsed.MediaDescriptions {
 		for _, a := range m.Attributes {
-			if a.IsICECandidate() {
+			switch {
+			case a.IsICECandidate():
 				sdpCandidate, err := a.ToICECandidate()
 				if err != nil {
 					return err
@@ -744,9 +749,9 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 				if err = pc.iceTransport.AddRemoteCandidate(candidate); err != nil {
 					return err
 				}
-			} else if strings.HasPrefix(*a.String(), "ice-ufrag") {
+			case strings.HasPrefix(*a.String(), "ice-ufrag"):
 				remoteUfrag = (*a.String())[len("ice-ufrag:"):]
-			} else if strings.HasPrefix(*a.String(), "ice-pwd") {
+			case strings.HasPrefix(*a.String(), "ice-pwd"):
 				remotePwd = (*a.String())[len("ice-pwd:"):]
 			}
 		}
@@ -869,11 +874,12 @@ func (pc *PeerConnection) openSRTP() {
 	for _, media := range pc.RemoteDescription().parsed.MediaDescriptions {
 		for _, attr := range media.Attributes {
 			var codecType RTPCodecType
-			if media.MediaName.Media == "audio" {
+			switch media.MediaName.Media {
+			case "audio":
 				codecType = RTPCodecTypeAudio
-			} else if media.MediaName.Media == "video" {
+			case "video":
 				codecType = RTPCodecTypeVideo
-			} else {
+			default:
 				continue
 			}
 
@@ -1395,11 +1401,12 @@ func (pc *PeerConnection) iceStateChange(newState ice.ConnectionState) {
 
 func localDirection(weSend bool, peerDirection RTPTransceiverDirection) RTPTransceiverDirection {
 	theySend := (peerDirection == RTPTransceiverDirectionSendrecv || peerDirection == RTPTransceiverDirectionSendonly)
-	if weSend && theySend {
+	switch {
+	case weSend && theySend:
 		return RTPTransceiverDirectionSendrecv
-	} else if weSend && !theySend {
+	case weSend && !theySend:
 		return RTPTransceiverDirectionSendonly
-	} else if !weSend && theySend {
+	case !weSend && theySend:
 		return RTPTransceiverDirectionRecvonly
 	}
 

--- a/pkg/ice/agent.go
+++ b/pkg/ice/agent.go
@@ -295,11 +295,12 @@ func allocateUDP(network string, url *URL) (*net.UDPAddr, *stun.XorAddress, erro
 }
 
 func (a *Agent) startConnectivityChecks(isControlling bool, remoteUfrag, remotePwd string) error {
-	if a.haveStarted {
+	switch {
+	case a.haveStarted:
 		return errors.Errorf("Attempted to start agent twice")
-	} else if remoteUfrag == "" {
+	case remoteUfrag == "":
 		return errors.Errorf("remoteUfrag is empty")
-	} else if remotePwd == "" {
+	case remotePwd == "":
 		return errors.Errorf("remotePwd is empty")
 	}
 	iceLog.Debugf("Started agent: isControlling? %t, remoteUfrag: %q, remotePwd: %q", isControlling, remoteUfrag, remotePwd)

--- a/pkg/ice/transport_test.go
+++ b/pkg/ice/transport_test.go
@@ -219,13 +219,13 @@ func pipe() (*Conn, *Conn) {
 	return aConn, bConn
 }
 
-func pipeWithTimeout(ICETimeout time.Duration, ICEKeepalive time.Duration) (*Conn, *Conn) {
+func pipeWithTimeout(iceTimeout time.Duration, iceKeepalive time.Duration) (*Conn, *Conn) {
 	var urls []*URL
 
 	aNotifier, aConnected := onConnected()
 	bNotifier, bConnected := onConnected()
 
-	aAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &ICETimeout, KeepaliveInterval: &ICEKeepalive})
+	aAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &iceTimeout, KeepaliveInterval: &iceKeepalive})
 	if err != nil {
 		panic(err)
 	}
@@ -234,7 +234,7 @@ func pipeWithTimeout(ICETimeout time.Duration, ICEKeepalive time.Duration) (*Con
 		panic(err)
 	}
 
-	bAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &ICETimeout, KeepaliveInterval: &ICEKeepalive})
+	bAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &iceTimeout, KeepaliveInterval: &iceKeepalive})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change enables the gocritic linter and fixes all reported errors.

The following errors were reported at the time of this submission:
```
› gocritic check ./...
./rtcpeerconnection.go:417:2: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:500:2: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:527:4: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:542:3: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:733:4: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:872:4: ifElseChain: rewrite if-else to switch statement
./rtcpeerconnection.go:1398:2: ifElseChain: rewrite if-else to switch statement
./rtcdatachannel_test.go:173:3: singleCaseSwitch: should rewrite switch statement to if statement
./pkg/ice/agent.go:298:2: ifElseChain: rewrite if-else to switch statement
./pkg/ice/transport_test.go:222:22: captLocal: `ICETimeout' should not be capitalized
./pkg/ice/transport_test.go:222:48: captLocal: `ICEKeepalive' should not be capitalized
```