### PR TITLE
API: Make initialisms more consistent

### DIFF
--- a/examples/gstreamer-receive/main.go
+++ b/examples/gstreamer-receive/main.go
@@ -42,7 +42,7 @@ func gstreamerReceiveMain() {
 		go func() {
 			ticker := time.NewTicker(time.Second * 3)
 			for range ticker.C {
-				err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.Ssrc})
+				err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.SSRC})
 				if err != nil {
 					fmt.Println(err)
 				}

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -100,7 +100,7 @@ func main() {
 	if msg.Jsep != nil {
 		err = peerConnection.SetRemoteDescription(webrtc.SessionDescription{
 			Type: webrtc.SDPTypeOffer,
-			Sdp:  msg.Jsep["sdp"].(string),
+			SDP:  msg.Jsep["sdp"].(string),
 		})
 		util.Check(err)
 
@@ -115,7 +115,7 @@ func main() {
 			"request": "start",
 		}, map[string]interface{}{
 			"type":    "answer",
-			"sdp":     answer.Sdp,
+			"sdp":     answer.SDP,
 			"trickle": false,
 		})
 		util.Check(err)

--- a/examples/janus-gateway/video-room/main.go
+++ b/examples/janus-gateway/video-room/main.go
@@ -100,7 +100,7 @@ func main() {
 		"data":    false,
 	}, map[string]interface{}{
 		"type":    "offer",
-		"sdp":     offer.Sdp,
+		"sdp":     offer.SDP,
 		"trickle": false,
 	})
 	util.Check(err)
@@ -108,7 +108,7 @@ func main() {
 	if msg.Jsep != nil {
 		err = peerConnection.SetRemoteDescription(webrtc.SessionDescription{
 			Type: webrtc.SDPTypeAnswer,
-			Sdp:  msg.Jsep["sdp"].(string),
+			SDP:  msg.Jsep["sdp"].(string),
 		})
 		util.Check(err)
 

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -41,7 +41,7 @@ func main() {
 		go func() {
 			ticker := time.NewTicker(time.Second * 3)
 			for range ticker.C {
-				err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.Ssrc})
+				err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.SSRC})
 				if err != nil {
 					fmt.Println(err)
 				}

--- a/examples/sfu/main.go
+++ b/examples/sfu/main.go
@@ -83,13 +83,13 @@ func main() {
 		go func() {
 			ticker := time.NewTicker(rtcpPLIInterval)
 			for range ticker.C {
-				if err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.Ssrc}); err != nil {
+				if err := peerConnection.SendRTCP(&rtcp.PictureLossIndication{MediaSSRC: track.SSRC}); err != nil {
 					fmt.Println(err)
 				}
 			}
 		}()
 
-		inboundSSRC <- track.Ssrc
+		inboundSSRC <- track.SSRC
 		inboundPayloadType <- track.PayloadType
 
 		for {
@@ -122,7 +122,7 @@ func main() {
 	// Get the LocalDescription and take it to base64 so we can paste in browser
 	fmt.Println(util.Encode(answer))
 
-	outboundSsrc := <-inboundSSRC
+	outboundSSRC := <-inboundSSRC
 	outboundPayloadType := <-inboundPayloadType
 	for {
 		fmt.Println("")
@@ -136,7 +136,7 @@ func main() {
 		util.Check(err)
 
 		// Create a single VP8 Track to send videa
-		vp8Track, err := peerConnection.NewRawRTPTrack(outboundPayloadType, outboundSsrc, "video", "pion")
+		vp8Track, err := peerConnection.NewRawRTPTrack(outboundPayloadType, outboundSSRC, "video", "pion")
 		util.Check(err)
 
 		_, err = peerConnection.AddTrack(vp8Track)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/pions/rtcp v1.0.0
 	github.com/pions/rtp v1.0.0
 	github.com/pions/sctp v1.3.1
-	github.com/pions/sdp v1.3.0
+	github.com/pions/sdp/v2 v2.0.0
 	github.com/pions/srtp v1.0.3
 	github.com/pions/stun v0.2.0
 	github.com/pions/transport v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/pions/rtp v1.0.0/go.mod h1:GDIt4UYlSz7za4vfaLqihGJJ+yLvgPshnqrF/lm3vc
 github.com/pions/sctp v1.3.0/go.mod h1:GZTG/xApE7wdUFEQq2Rmzgxl/+YaB/L1k8xUl1D5bmo=
 github.com/pions/sctp v1.3.1 h1:V5cRHMt+G9ufc44ITZvcEj7/nUyDukkB3Qr08TT29k4=
 github.com/pions/sctp v1.3.1/go.mod h1:GZTG/xApE7wdUFEQq2Rmzgxl/+YaB/L1k8xUl1D5bmo=
-github.com/pions/sdp v1.3.0 h1:HIv6ZvdzRPq+H4T8EV8K9pZ4EGnYOr14HFZ9Rksh6/0=
-github.com/pions/sdp v1.3.0/go.mod h1:moNMmnVSlx8rBBb39U9t0Rdr7xvMlqiJjHlMESRad5k=
+github.com/pions/sdp/v2 v2.0.0 h1:tWh8ehKPtXTaFYF12sBAHqYmhV36Q7YTmm3O6ycNa6M=
+github.com/pions/sdp/v2 v2.0.0/go.mod h1:KGRBcHfpkgJXjrzKJz2wj/Jf1KWnsHdoIiqtayQ5QmE=
 github.com/pions/srtp v1.0.3 h1:0rlg7yUHQblFA1e451mhx50IkA7+e48ja5K8mljyMYY=
 github.com/pions/srtp v1.0.3/go.mod h1:egXe0STDyQDXLm7hjOMzuk7rkAhJ1SHOx+tTgtw/cQs=
 github.com/pions/stun v0.2.0 h1:spIzpfkEg6HV+2iIo6qeOsAjtadZKzbXbrd2e9ZCCcs=

--- a/icecandidate.go
+++ b/icecandidate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 	"github.com/pions/webrtc/pkg/ice"
 )
 

--- a/icecandidate_test.go
+++ b/icecandidate_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 	"github.com/pions/webrtc/pkg/ice"
 	"github.com/stretchr/testify/assert"
 )

--- a/iceserver_test.go
+++ b/iceserver_test.go
@@ -24,7 +24,7 @@ func TestICEServer_validate(t *testing.T) {
 				URLs:     []string{"turn:192.158.29.39?transport=udp"},
 				Username: "unittest",
 				Credential: OAuthCredential{
-					MacKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+					MACKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
 					AccessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ5VhNDgeMR3+ZlZ35byg972fW8QjpEl7bx91YLBPFsIhsxloWcXPhA==",
 				},
 				CredentialType: ICECredentialTypeOauth,

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pions/rtp"
 	"github.com/pions/rtp/codecs"
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 )
 
 // PayloadTypes for the default codecs

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -53,7 +53,7 @@ func (m *MediaEngine) getCodecSDP(sdpCodec sdp.Codec) (*RTPCodec, error) {
 			codec.ClockRate == sdpCodec.ClockRate &&
 			(sdpCodec.EncodingParameters == "" ||
 				strconv.Itoa(int(codec.Channels)) == sdpCodec.EncodingParameters) &&
-			codec.SdpFmtpLine == sdpCodec.Fmtp { // TODO: Protocol specific matching?
+			codec.SDPFmtpLine == sdpCodec.Fmtp { // TODO: Protocol specific matching?
 			return codec, nil
 		}
 	}
@@ -186,7 +186,7 @@ func NewRTPCodec(
 			MimeType:    codecType.String() + "/" + name,
 			ClockRate:   clockrate,
 			Channels:    channels,
-			SdpFmtpLine: fmtp,
+			SDPFmtpLine: fmtp,
 		},
 		PayloadType: payloadType,
 		Payloader:   payloader,
@@ -200,7 +200,7 @@ type RTPCodecCapability struct {
 	MimeType    string
 	ClockRate   uint32
 	Channels    uint16
-	SdpFmtpLine string
+	SDPFmtpLine string
 }
 
 // RTPHeaderExtensionCapability is used to define a RFC5285 RTP header extension supported by the codec.

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -3,7 +3,7 @@ package webrtc
 import (
 	"testing"
 
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/oauthcredential.go
+++ b/oauthcredential.go
@@ -5,9 +5,9 @@ package webrtc
 // https://tools.ietf.org/html/rfc7635. Note that the kid parameter is not
 // located in OAuthCredential, but in ICEServer's username member.
 type OAuthCredential struct {
-	// MacKey is a base64-url encoded format. It is used in STUN message
+	// MACKey is a base64-url encoded format. It is used in STUN message
 	// integrity hash calculation.
-	MacKey string
+	MACKey string
 
 	// AccessToken is a base64-encoded format. This is an encrypted
 	// self-contained token that is opaque to the application.

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pions/rtcp"
 	"github.com/pions/rtp"
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 	"github.com/pions/webrtc/pkg/ice"
 	"github.com/pions/webrtc/pkg/logging"
 	"github.com/pions/webrtc/pkg/rtcerr"
@@ -1428,8 +1428,8 @@ func (pc *PeerConnection) addRTPMediaSection(d *sdp.SessionDescription, codecTyp
 		WithValueAttribute(sdp.AttrKeyConnectionSetup, dtlsRole.String()). // TODO: Support other connection types
 		WithValueAttribute(sdp.AttrKeyMID, midValue).
 		WithICECredentials(iceParams.UsernameFragment, iceParams.Password).
-		WithPropertyAttribute(sdp.AttrKeyRtcpMux).  // TODO: support RTCP fallback
-		WithPropertyAttribute(sdp.AttrKeyRtcpRsize) // TODO: Support Reduced-Size RTCP?
+		WithPropertyAttribute(sdp.AttrKeyRTCPMux).  // TODO: support RTCP fallback
+		WithPropertyAttribute(sdp.AttrKeyRTCPRsize) // TODO: Support Reduced-Size RTCP?
 
 	for _, codec := range pc.api.mediaEngine.getCodecsByKind(codecType) {
 		media.WithCodec(codec.PayloadType, codec.Name, codec.ClockRate, codec.Channels, codec.SDPFmtpLine)

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -832,7 +832,7 @@ func (pc *PeerConnection) SetRemoteDescription(desc SessionDescription) error {
 			if tranceiver.Sender != nil {
 				tranceiver.Sender.Send(RTPSendParameters{
 					encodings: RTPEncodingParameters{
-						RTPCodingParameters{SSRC: tranceiver.Sender.Track.Ssrc, PayloadType: tranceiver.Sender.Track.PayloadType},
+						RTPCodingParameters{SSRC: tranceiver.Sender.Track.SSRC, PayloadType: tranceiver.Sender.Track.PayloadType},
 					}})
 			}
 		}
@@ -883,7 +883,7 @@ func (pc *PeerConnection) openSRTP() {
 				continue
 			}
 
-			if attr.Key == sdp.AttrKeySsrc {
+			if attr.Key == sdp.AttrKeySSRC {
 				ssrc, err := strconv.ParseUint(strings.Split(attr.Value, " ")[0], 10, 32)
 				if err != nil {
 					pcLog.Warnf("Failed to parse SSRC: %v", err)
@@ -1444,7 +1444,7 @@ func (pc *PeerConnection) addRTPMediaSection(d *sdp.SessionDescription, codecTyp
 		}
 		weSend = true
 		track := transceiver.Sender.Track
-		media = media.WithMediaSource(track.Ssrc, track.Label /* cname */, track.Label /* streamLabel */, track.Label)
+		media = media.WithMediaSource(track.SSRC, track.Label /* cname */, track.Label /* streamLabel */, track.Label)
 	}
 	media = media.WithPropertyAttribute(localDirection(weSend, peerDirection).String())
 

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -40,7 +40,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		go func() {
 			for {
 				time.Sleep(time.Millisecond * 100)
-				if routineErr := pcAnswer.SendRTCP(&rtcp.RapidResynchronizationRequest{SenderSSRC: track.Ssrc, MediaSSRC: track.Ssrc}); routineErr != nil {
+				if routineErr := pcAnswer.SendRTCP(&rtcp.RapidResynchronizationRequest{SenderSSRC: track.SSRC, MediaSSRC: track.SSRC}); routineErr != nil {
 					awaitRTCPRecieverSend <- routineErr
 					return
 				}
@@ -97,7 +97,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
-			if routineErr := pcOffer.SendRTCP(&rtcp.PictureLossIndication{SenderSSRC: vp8Track.Ssrc, MediaSSRC: vp8Track.Ssrc}); routineErr != nil {
+			if routineErr := pcOffer.SendRTCP(&rtcp.PictureLossIndication{SenderSSRC: vp8Track.SSRC, MediaSSRC: vp8Track.SSRC}); routineErr != nil {
 				awaitRTCPSenderSend <- routineErr
 			}
 

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -382,7 +382,7 @@ func TestSetRemoteDescription(t *testing.T) {
 	testCases := []struct {
 		desc SessionDescription
 	}{
-		{SessionDescription{Type: SDPTypeOffer, Sdp: minimalOffer}},
+		{SessionDescription{Type: SDPTypeOffer, SDP: minimalOffer}},
 	}
 
 	for i, testCase := range testCases {

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -82,7 +82,7 @@ func TestNew(t *testing.T) {
 					},
 					Username: "unittest",
 					Credential: OAuthCredential{
-						MacKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+						MACKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
 						AccessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ==",
 					},
 					CredentialType: ICECredentialTypeOauth,
@@ -185,7 +185,7 @@ func TestPeerConnection_SetConfiguration(t *testing.T) {
 							},
 							Username: "unittest",
 							Credential: OAuthCredential{
-								MacKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
+								MACKey:      "WmtzanB3ZW9peFhtdm42NzUzNG0=",
 								AccessToken: "AAwg3kPHWPfvk9bDFL936wYvkoctMADzQ==",
 							},
 							CredentialType: ICECredentialTypeOauth,

--- a/rtpreceiver.go
+++ b/rtpreceiver.go
@@ -51,7 +51,7 @@ func (r *RTPReceiver) Receive(parameters RTPReceiveParameters) chan bool {
 	// TODO atomic only allow this to fire once
 	r.Track = &Track{
 		Kind:        r.kind,
-		Ssrc:        parameters.encodings.SSRC,
+		SSRC:        parameters.encodings.SSRC,
 		Packets:     r.rtpOut,
 		RTCPPackets: r.rtcpOut,
 	}

--- a/rtpsender.go
+++ b/rtpsender.go
@@ -76,7 +76,7 @@ func (r *RTPSender) handleSampleRTP(rtpPackets chan media.Sample) {
 	packetizer := rtp.NewPacketizer(
 		rtpOutboundMTU,
 		r.Track.PayloadType,
-		r.Track.Ssrc,
+		r.Track.SSRC,
 		r.Track.Codec.Payloader,
 		rtp.NewRandomSequencer(),
 		r.Track.Codec.ClockRate,
@@ -98,13 +98,13 @@ func (r *RTPSender) handleSampleRTP(rtpPackets chan media.Sample) {
 func (r *RTPSender) handleRTCP(transport *DTLSTransport, rtcpPackets chan rtcp.Packet) {
 	srtcpSession, err := transport.getSRTCPSession()
 	if err != nil {
-		pcLog.Warnf("Failed to open SRTCPSession, Track done for: %v %d \n", err, r.Track.Ssrc)
+		pcLog.Warnf("Failed to open SRTCPSession, Track done for: %v %d \n", err, r.Track.SSRC)
 		return
 	}
 
-	readStream, err := srtcpSession.OpenReadStream(r.Track.Ssrc)
+	readStream, err := srtcpSession.OpenReadStream(r.Track.SSRC)
 	if err != nil {
-		pcLog.Warnf("Failed to open RTCP ReadStream, Track done for: %v %d \n", err, r.Track.Ssrc)
+		pcLog.Warnf("Failed to open RTCP ReadStream, Track done for: %v %d \n", err, r.Track.SSRC)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (r *RTPSender) handleRTCP(transport *DTLSTransport, rtcpPackets chan rtcp.P
 		rtcpBuf := make([]byte, receiveMTU)
 		i, err := readStream.Read(rtcpBuf)
 		if err != nil {
-			pcLog.Warnf("Failed to read, Track done for: %v %d \n", err, r.Track.Ssrc)
+			pcLog.Warnf("Failed to read, Track done for: %v %d \n", err, r.Track.SSRC)
 			return
 		}
 

--- a/sdptype_test.go
+++ b/sdptype_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewSDPType(t *testing.T) {
 	testCases := []struct {
 		sdpTypeString   string
-		expectedSdpType SDPType
+		expectedSDPType SDPType
 	}{
 		{unknownStr, SDPType(Unknown)},
 		{"offer", SDPTypeOffer},
@@ -20,7 +20,7 @@ func TestNewSDPType(t *testing.T) {
 
 	for i, testCase := range testCases {
 		assert.Equal(t,
-			testCase.expectedSdpType,
+			testCase.expectedSDPType,
 			newSDPType(testCase.sdpTypeString),
 			"testCase: %d %v", i, testCase,
 		)

--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -1,7 +1,7 @@
 package webrtc
 
 import (
-	"github.com/pions/sdp"
+	"github.com/pions/sdp/v2"
 )
 
 // SessionDescription is used to expose local and remote session descriptions.

--- a/sessiondescription.go
+++ b/sessiondescription.go
@@ -7,7 +7,7 @@ import (
 // SessionDescription is used to expose local and remote session descriptions.
 type SessionDescription struct {
 	Type SDPType `json:"type"`
-	Sdp  string  `json:"sdp"`
+	SDP  string  `json:"sdp"`
 
 	// This will never be initialized by callers, internal use only
 	parsed *sdp.SessionDescription

--- a/sessiondescription_test.go
+++ b/sessiondescription_test.go
@@ -13,11 +13,11 @@ func TestSessionDescription_JSON(t *testing.T) {
 		expectedString string
 		unmarshalErr   error
 	}{
-		{SessionDescription{Type: SDPTypeOffer, Sdp: "sdp"}, `{"type":"offer","sdp":"sdp"}`, nil},
-		{SessionDescription{Type: SDPTypePranswer, Sdp: "sdp"}, `{"type":"pranswer","sdp":"sdp"}`, nil},
-		{SessionDescription{Type: SDPTypeAnswer, Sdp: "sdp"}, `{"type":"answer","sdp":"sdp"}`, nil},
-		{SessionDescription{Type: SDPTypeRollback, Sdp: "sdp"}, `{"type":"rollback","sdp":"sdp"}`, nil},
-		{SessionDescription{Type: SDPType(Unknown), Sdp: "sdp"}, `{"type":"unknown","sdp":"sdp"}`, ErrUnknownType},
+		{SessionDescription{Type: SDPTypeOffer, SDP: "sdp"}, `{"type":"offer","sdp":"sdp"}`, nil},
+		{SessionDescription{Type: SDPTypePranswer, SDP: "sdp"}, `{"type":"pranswer","sdp":"sdp"}`, nil},
+		{SessionDescription{Type: SDPTypeAnswer, SDP: "sdp"}, `{"type":"answer","sdp":"sdp"}`, nil},
+		{SessionDescription{Type: SDPTypeRollback, SDP: "sdp"}, `{"type":"rollback","sdp":"sdp"}`, nil},
+		{SessionDescription{Type: SDPType(Unknown), SDP: "sdp"}, `{"type":"unknown","sdp":"sdp"}`, ErrUnknownType},
 	}
 
 	for i, testCase := range testCases {

--- a/track.go
+++ b/track.go
@@ -21,7 +21,7 @@ type Track struct {
 	PayloadType uint8
 	Kind        RTPCodecType
 	Label       string
-	Ssrc        uint32
+	SSRC        uint32
 	Codec       *RTPCodec
 
 	Packets     <-chan *rtp.Packet
@@ -47,7 +47,7 @@ func NewRawRTPTrack(payloadType uint8, ssrc uint32, id, label string, codec *RTP
 		PayloadType: payloadType,
 		Kind:        codec.Type,
 		Label:       label,
-		Ssrc:        ssrc,
+		SSRC:        ssrc,
 		Codec:       codec,
 	}, nil
 }
@@ -70,7 +70,7 @@ func NewSampleTrack(payloadType uint8, id, label string, codec *RTPCodec) (*Trac
 		PayloadType: payloadType,
 		Kind:        codec.Type,
 		Label:       label,
-		Ssrc:        binary.LittleEndian.Uint32(buf),
+		SSRC:        binary.LittleEndian.Uint32(buf),
 		Codec:       codec,
 	}, nil
 }


### PR DESCRIPTION
Change capitalization to be consistent with other uses in the project, and to match the Go convention of capitalizing initialisms:

https://github.com/golang/go/wiki/CodeReviewComments#initialisms
    
Relates to #417