### PR TITLE
Remove global API for settings engine

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,9 +1,5 @@
 package webrtc
 
-import (
-	"time"
-)
-
 // API bundles the global funcions of the WebRTC and ORTC API.
 // Some of these functions are also exported globally using the
 // defaultAPI object. Note that the global version of the API
@@ -52,26 +48,6 @@ func WithSettingEngine(s SettingEngine) func(a *API) {
 // This global API should not be extended and may be phased out
 // in the future.
 var defaultAPI = NewAPI()
-
-// Setting engine API
-
-// SetEphemeralUDPPortRange on the default API.
-// See SettingEngine for details.
-func SetEphemeralUDPPortRange(portMin, portMax uint16) error {
-	return defaultAPI.settingEngine.SetEphemeralUDPPortRange(portMin, portMax)
-}
-
-// DetachDataChannels on the default API.
-// See SettingEngine for details.
-func DetachDataChannels() {
-	defaultAPI.settingEngine.DetachDataChannels()
-}
-
-// SetConnectionTimeout on the default API.
-// See SettingEngine for details.
-func SetConnectionTimeout(connectionTimeout, keepAlive time.Duration) {
-	defaultAPI.settingEngine.SetConnectionTimeout(connectionTimeout, keepAlive)
-}
 
 // Media Engine API
 

--- a/examples/data-channels-detach-create/main.go
+++ b/examples/data-channels-detach-create/main.go
@@ -14,9 +14,15 @@ const messageSize = 15
 
 func main() {
 	// Since this behavior diverges from the WebRTC API it has to be
-	// enabled using global switch.
-	// Mixing both behaviors is not supported.
-	webrtc.DetachDataChannels()
+	// enabled using a settings engine. Mixing both detached and the
+	// OnMessage DataChannel API is not supported.
+
+	// Create a SettingEngine and enable Detach
+	s := webrtc.SettingEngine{}
+	s.DetachDataChannels()
+
+	// Create an API object with the engine
+	api := webrtc.NewAPI(webrtc.WithSettingEngine(s))
 
 	// Everything below is the pion-WebRTC API! Thanks for using it ❤️.
 
@@ -29,8 +35,8 @@ func main() {
 		},
 	}
 
-	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.NewPeerConnection(config)
+	// Create a new RTCPeerConnection using the API object
+	peerConnection, err := api.NewPeerConnection(config)
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +87,7 @@ func main() {
 
 	// Wait for the answer to be pasted
 	answer := webrtc.SessionDescription{}
-	signal.Decode(signal.MustReadStdin(), answer)
+	signal.Decode(signal.MustReadStdin(), &answer)
 
 	// Apply the answer as the remote description
 	err = peerConnection.SetRemoteDescription(answer)

--- a/examples/data-channels-detach/main.go
+++ b/examples/data-channels-detach/main.go
@@ -14,9 +14,15 @@ const messageSize = 15
 
 func main() {
 	// Since this behavior diverges from the WebRTC API it has to be
-	// enabled using global switch.
-	// Mixing both behaviors is not supported.
-	webrtc.DetachDataChannels()
+	// enabled using a settings engine. Mixing both detached and the
+	// OnMessage DataChannel API is not supported.
+
+	// Create a SettingEngine and enable Detach
+	s := webrtc.SettingEngine{}
+	s.DetachDataChannels()
+
+	// Create an API object with the engine
+	api := webrtc.NewAPI(webrtc.WithSettingEngine(s))
 
 	// Everything below is the pion-WebRTC API! Thanks for using it ❤️.
 
@@ -29,8 +35,8 @@ func main() {
 		},
 	}
 
-	// Create a new RTCPeerConnection
-	peerConnection, err := webrtc.NewPeerConnection(config)
+	// Create a new RTCPeerConnection using the API object
+	peerConnection, err := api.NewPeerConnection(config)
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +71,7 @@ func main() {
 
 	// Wait for the offer to be pasted
 	offer := webrtc.SessionDescription{}
-	signal.Decode(signal.MustReadStdin(), offer)
+	signal.Decode(signal.MustReadStdin(), &offer)
 
 	// Set the remote SessionDescription
 	err = peerConnection.SetRemoteDescription(offer)


### PR DESCRIPTION
Limit global API to the basics needed to construct a PeerConnection.