### PR TITLE
Move to new Track API

### DIFF
--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -156,8 +156,10 @@ func TestDataChannel_MessagesAreOrdered(t *testing.T) {
 	out := make(chan int)
 	inner := func(msg DataChannelMessage) {
 		// randomly sleep
-		// NB: The big.Int/crypto.Rand is overkill but makes the linter happy
+		// math/rand a weak RNG, but this does not need to be secure. Ignore with #nosec
+		/* #nosec */
 		randInt, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+		/* #nosec */
 		if err != nil {
 			t.Fatalf("Failed to get random sleep duration: %s", err)
 		}

--- a/examples/gstreamer-send-offer/main.go
+++ b/examples/gstreamer-send-offer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 
 	"github.com/pions/webrtc"
 
@@ -34,7 +35,7 @@ func main() {
 	})
 
 	// Create a audio track
-	opusTrack, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")
+	opusTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +45,7 @@ func main() {
 	}
 
 	// Create a video track
-	vp8Track, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
+	vp8Track, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		panic(err)
 	}
@@ -79,8 +80,8 @@ func main() {
 	}
 
 	// Start pushing buffers on these tracks
-	gst.CreatePipeline(webrtc.Opus, opusTrack.Samples, "audiotestsrc").Start()
-	gst.CreatePipeline(webrtc.VP8, vp8Track.Samples, "videotestsrc").Start()
+	gst.CreatePipeline(webrtc.Opus, opusTrack, "audiotestsrc").Start()
+	gst.CreatePipeline(webrtc.VP8, vp8Track, "videotestsrc").Start()
 
 	// Block forever
 	select {}

--- a/examples/gstreamer-send/main.go
+++ b/examples/gstreamer-send/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 
 	"github.com/pions/webrtc"
 
@@ -39,7 +40,7 @@ func main() {
 	})
 
 	// Create a audio track
-	opusTrack, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")
+	opusTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +50,7 @@ func main() {
 	}
 
 	// Create a video track
-	vp8Track, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
+	vp8Track, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		panic(err)
 	}
@@ -84,8 +85,8 @@ func main() {
 	fmt.Println(signal.Encode(answer))
 
 	// Start pushing buffers on these tracks
-	gst.CreatePipeline(webrtc.Opus, opusTrack.Samples, *audioSrc).Start()
-	gst.CreatePipeline(webrtc.VP8, vp8Track.Samples, *videoSrc).Start()
+	gst.CreatePipeline(webrtc.Opus, opusTrack, *audioSrc).Start()
+	gst.CreatePipeline(webrtc.VP8, vp8Track, *videoSrc).Start()
 
 	// Block forever
 	select {}

--- a/examples/internal/gstreamer-src/gst.go
+++ b/examples/internal/gstreamer-src/gst.go
@@ -23,7 +23,7 @@ func init() {
 // Pipeline is a wrapper for a GStreamer Pipeline
 type Pipeline struct {
 	Pipeline *C.GstElement
-	in       chan<- media.Sample
+	track    *webrtc.Track
 	// stop acts as a signal that this pipeline is stopped
 	// any pending sends to Pipeline.in should be cancelled
 	stop      chan interface{}
@@ -35,7 +35,7 @@ var pipelines = make(map[int]*Pipeline)
 var pipelinesLock sync.Mutex
 
 // CreatePipeline creates a GStreamer Pipeline
-func CreatePipeline(codecName string, in chan<- media.Sample, pipelineSrc string) *Pipeline {
+func CreatePipeline(codecName string, track *webrtc.Track, pipelineSrc string) *Pipeline {
 	pipelineStr := "appsink name=appsink"
 	switch codecName {
 	case webrtc.VP8:
@@ -60,7 +60,7 @@ func CreatePipeline(codecName string, in chan<- media.Sample, pipelineSrc string
 
 	pipeline := &Pipeline{
 		Pipeline:  C.gstreamer_send_create_pipeline(pipelineStrUnsafe),
-		in:        in,
+		track:     track,
 		id:        len(pipelines),
 		codecName: codecName,
 	}
@@ -105,9 +105,8 @@ func goHandlePipelineBuffer(buffer unsafe.Pointer, bufferLen C.int, duration C.i
 		}
 		// We need to be able to cancel this function even f pipeline.in isn't being serviced
 		// When pipeline.stop is closed the sending of data will be cancelled.
-		select {
-		case pipeline.in <- media.Sample{Data: C.GoBytes(buffer, bufferLen), Samples: samples}:
-		case <-pipeline.stop:
+		if err := pipeline.track.WriteSample(media.Sample{Data: C.GoBytes(buffer, bufferLen), Samples: samples}); err != nil {
+			panic(err)
 		}
 	} else {
 		fmt.Printf("discarding buffer, no pipeline with id %d", int(pipelineID))

--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -52,8 +52,8 @@ func main() {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	})
 
-	peerConnection.OnTrack(func(track *webrtc.Track) {
-		if track.Codec.Name == webrtc.Opus {
+	peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
+		if track.Codec().Name == webrtc.Opus {
 			return
 		}
 
@@ -62,8 +62,14 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+
 		for {
-			err = i.AddPacket(<-track.Packets)
+			packet, err := track.ReadRTP()
+			if err != nil {
+				panic(err)
+			}
+
+			err = i.AddPacket(packet)
 			if err != nil {
 				panic(err)
 			}

--- a/examples/janus-gateway/video-room/main.go
+++ b/examples/janus-gateway/video-room/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"math/rand"
 
 	janus "github.com/notedit/janus-go"
 	"github.com/pions/webrtc"
@@ -54,7 +55,7 @@ func main() {
 	})
 
 	// Create a audio track
-	opusTrack, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeOpus, "audio", "pion1")
+	opusTrack, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +65,7 @@ func main() {
 	}
 
 	// Create a video track
-	vp8Track, err := peerConnection.NewSampleTrack(webrtc.DefaultPayloadTypeVP8, "video", "pion2")
+	vp8Track, err := peerConnection.NewTrack(webrtc.DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		panic(err)
 	}
@@ -134,8 +135,8 @@ func main() {
 		}
 
 		// Start pushing buffers on these tracks
-		gst.CreatePipeline(webrtc.Opus, opusTrack.Samples, "audiotestsrc").Start()
-		gst.CreatePipeline(webrtc.VP8, vp8Track.Samples, "videotestsrc").Start()
+		gst.CreatePipeline(webrtc.Opus, opusTrack, "audiotestsrc").Start()
+		gst.CreatePipeline(webrtc.VP8, vp8Track, "videotestsrc").Start()
 	}
 
 	select {}

--- a/lossy_stream.go
+++ b/lossy_stream.go
@@ -1,0 +1,93 @@
+package webrtc
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// lossyReader wraps an io.Reader and discards data if it isn't read in time
+// Allowing us to only deliver the newest data to the caller
+type lossyReadCloser struct {
+	nextReader io.ReadCloser
+	mu         sync.RWMutex
+
+	incomingBuf chan []byte
+	amountRead  chan int
+
+	readError  error
+	hasErrored chan interface{}
+
+	closed chan interface{}
+}
+
+func newLossyReadCloser(nextReader io.ReadCloser) *lossyReadCloser {
+	l := &lossyReadCloser{
+		nextReader: nextReader,
+
+		closed: make(chan interface{}),
+
+		incomingBuf: make(chan []byte),
+		hasErrored:  make(chan interface{}),
+		amountRead:  make(chan int),
+	}
+
+	go func() {
+		readBuf := make([]byte, receiveMTU)
+		for {
+			i, err := nextReader.Read(readBuf)
+			if err != nil {
+				l.mu.Lock()
+				l.readError = err
+				l.mu.Unlock()
+
+				close(l.hasErrored)
+				break
+			}
+
+			select {
+			case in := <-l.incomingBuf:
+				copy(in, readBuf[:i])
+				l.amountRead <- i
+			default: // Discard if we have no inbound read
+			}
+		}
+	}()
+
+	return l
+}
+
+func (l *lossyReadCloser) Read(b []byte) (n int, err error) {
+	select {
+	case <-l.closed:
+		return 0, fmt.Errorf("lossyReadCloser is closed")
+	case <-l.hasErrored:
+		l.mu.RLock()
+		defer l.mu.RUnlock()
+		return 0, l.readError
+
+	case l.incomingBuf <- b:
+	}
+
+	select {
+	case <-l.closed:
+		return 0, fmt.Errorf("lossyReadCloser is closed")
+	case <-l.hasErrored:
+		l.mu.RLock()
+		defer l.mu.RUnlock()
+		return 0, l.readError
+
+	case i := <-l.amountRead:
+		return i, nil
+	}
+}
+
+func (l *lossyReadCloser) Close() error {
+	select {
+	case <-l.closed:
+		return fmt.Errorf("lossyReader is already closed")
+	default:
+	}
+	close(l.closed)
+	return l.nextReader.Close()
+}

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -2,6 +2,8 @@ package webrtc
 
 import (
 	"bytes"
+	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -32,14 +34,14 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	awaitRTCPSenderRecv := make(chan bool)
 	awaitRTCPSenderSend := make(chan error)
 
-	awaitRTCPRecieverRecv := make(chan bool)
+	awaitRTCPRecieverRecv := make(chan error)
 	awaitRTCPRecieverSend := make(chan error)
 
-	pcAnswer.OnTrack(func(track *Track) {
+	pcAnswer.OnTrack(func(track *Track, receiver *RTPReceiver) {
 		go func() {
 			for {
 				time.Sleep(time.Millisecond * 100)
-				if routineErr := pcAnswer.SendRTCP(&rtcp.RapidResynchronizationRequest{SenderSSRC: track.SSRC, MediaSSRC: track.SSRC}); routineErr != nil {
+				if routineErr := pcAnswer.SendRTCP(&rtcp.RapidResynchronizationRequest{SenderSSRC: track.SSRC(), MediaSSRC: track.SSRC()}); routineErr != nil {
 					awaitRTCPRecieverSend <- routineErr
 					return
 				}
@@ -54,14 +56,18 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		}()
 
 		go func() {
-			<-track.RTCPPackets
-			close(awaitRTCPRecieverRecv)
+			_, routineErr := receiver.Read(make([]byte, 1400))
+			if routineErr != nil {
+				awaitRTCPRecieverRecv <- routineErr
+			} else {
+				close(awaitRTCPRecieverRecv)
+			}
 		}()
 
 		haveClosedAwaitRTPRecv := false
 		for {
-			p, ok := <-track.Packets
-			if !ok {
+			p, routineErr := track.ReadRTP()
+			if routineErr != nil {
 				close(awaitRTPRecvClosed)
 				return
 			} else if bytes.Equal(p.Payload, []byte{0x10, 0x00}) && !haveClosedAwaitRTPRecv {
@@ -71,18 +77,21 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 		}
 	})
 
-	vp8Track, err := pcOffer.NewSampleTrack(DefaultPayloadTypeVP8, "video", "pion")
+	vp8Track, err := pcOffer.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = pcOffer.AddTrack(vp8Track); err != nil {
+	rtpReceiver, err := pcOffer.AddTrack(vp8Track)
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
-			vp8Track.Samples <- media.Sample{Data: []byte{0x00}, Samples: 1}
+			if routineErr := vp8Track.WriteSample(media.Sample{Data: []byte{0x00}, Samples: 1}); routineErr != nil {
+				fmt.Println(routineErr)
+			}
 
 			select {
 			case <-awaitRTPRecv:
@@ -96,7 +105,7 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 100)
-			if routineErr := pcOffer.SendRTCP(&rtcp.PictureLossIndication{SenderSSRC: vp8Track.SSRC, MediaSSRC: vp8Track.SSRC}); routineErr != nil {
+			if routineErr := pcOffer.SendRTCP(&rtcp.PictureLossIndication{SenderSSRC: vp8Track.SSRC(), MediaSSRC: vp8Track.SSRC()}); routineErr != nil {
 				awaitRTCPSenderSend <- routineErr
 			}
 
@@ -110,8 +119,9 @@ func TestPeerConnection_Media_Sample(t *testing.T) {
 	}()
 
 	go func() {
-		<-vp8Track.RTCPPackets
-		close(awaitRTCPSenderRecv)
+		if _, routineErr := rtpReceiver.Read(make([]byte, 1400)); routineErr == nil {
+			close(awaitRTCPSenderRecv)
+		}
 	}()
 
 	err = signalPair(pcOffer, pcAnswer)
@@ -158,38 +168,41 @@ This test adds an input track and asserts
 func TestPeerConnection_Media_Shutdown(t *testing.T) {
 	iceComplete := make(chan bool)
 
-	api := NewAPI()
 	lim := test.TimeOut(time.Second * 30)
 	defer lim.Stop()
 
 	report := test.CheckRoutines(t)
 	defer report()
 
-	api.mediaEngine.RegisterDefaultCodecs()
-	pcOffer, pcAnswer, err := api.newPair()
+	pcOffer, err := NewPeerConnection(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	opusTrack, err := pcOffer.NewSampleTrack(DefaultPayloadTypeOpus, "audio", "pion1")
+	pcAnswer, err := NewPeerConnection(Configuration{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	vp8Track, err := pcOffer.NewSampleTrack(DefaultPayloadTypeVP8, "video", "pion2")
+
+	opusTrack, err := pcOffer.NewTrack(DefaultPayloadTypeOpus, rand.Uint32(), "audio", "pion1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	vp8Track, err := pcOffer.NewTrack(DefaultPayloadTypeVP8, rand.Uint32(), "video", "pion2")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if _, err = pcOffer.AddTrack(opusTrack); err != nil {
 		t.Fatal(err)
-	} else if _, err = pcOffer.AddTrack(vp8Track); err != nil {
+	} else if _, err = pcAnswer.AddTrack(vp8Track); err != nil {
 		t.Fatal(err)
 	}
 
 	var onTrackFiredLock sync.RWMutex
 	onTrackFired := false
 
-	pcAnswer.OnTrack(func(track *Track) {
+	pcAnswer.OnTrack(func(track *Track, receiver *RTPReceiver) {
 		onTrackFiredLock.Lock()
 		defer onTrackFiredLock.Unlock()
 		onTrackFired = true
@@ -208,8 +221,25 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	<-iceComplete
+
+	// Each PeerConnection should have one sender, one receiver and two transceivers
+	for _, pc := range []*PeerConnection{pcOffer, pcAnswer} {
+		senders := pc.GetSenders()
+		if len(senders) != 1 {
+			t.Errorf("Each PeerConnection should have one RTPSender, we have %d", len(senders))
+		}
+
+		receivers := pc.GetReceivers()
+		if len(receivers) != 1 {
+			t.Errorf("Each PeerConnection should have one RTPReceiver, we have %d", len(receivers))
+		}
+
+		transceivers := pc.GetTransceivers()
+		if len(transceivers) != 2 {
+			t.Errorf("Each PeerConnection should have two RTPTransceivers, we have %d", len(transceivers))
+		}
+	}
 
 	err = pcOffer.Close()
 	if err != nil {
@@ -226,5 +256,4 @@ func TestPeerConnection_Media_Shutdown(t *testing.T) {
 		t.Fatalf("PeerConnection OnTrack fired even though we got no packets")
 	}
 	onTrackFiredLock.Unlock()
-
 }

--- a/pkg/ice/ice_test.go
+++ b/pkg/ice/ice_test.go
@@ -1,0 +1,51 @@
+package ice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectedState_String(t *testing.T) {
+	testCases := []struct {
+		connectionState ConnectionState
+		expectedString  string
+	}{
+		{ConnectionState(Unknown), "Invalid"},
+		{ConnectionStateNew, "New"},
+		{ConnectionStateChecking, "Checking"},
+		{ConnectionStateConnected, "Connected"},
+		{ConnectionStateCompleted, "Completed"},
+		{ConnectionStateFailed, "Failed"},
+		{ConnectionStateDisconnected, "Disconnected"},
+		{ConnectionStateClosed, "Closed"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.connectionState.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestGatheringState_String(t *testing.T) {
+	testCases := []struct {
+		gatheringState GatheringState
+		expectedString string
+	}{
+		{GatheringState(Unknown), ErrUnknownType.Error()},
+		{GatheringStateNew, "new"},
+		{GatheringStateGathering, "gathering"},
+		{GatheringStateComplete, "complete"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.gatheringState.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/rtptranceiver.go
+++ b/rtptranceiver.go
@@ -17,7 +17,7 @@ type RTPTransceiver struct {
 }
 
 func (t *RTPTransceiver) setSendingTrack(track *Track) error {
-	t.Sender.Track = track
+	t.Sender.track = track
 
 	switch t.Direction {
 	case RTPTransceiverDirectionRecvonly:
@@ -33,7 +33,9 @@ func (t *RTPTransceiver) setSendingTrack(track *Track) error {
 // Stop irreversibly stops the RTPTransceiver
 func (t *RTPTransceiver) Stop() error {
 	if t.Sender != nil {
-		t.Sender.Stop()
+		if err := t.Sender.Stop(); err != nil {
+			return err
+		}
 	}
 	if t.Receiver != nil {
 		if err := t.Receiver.Stop(); err != nil {

--- a/track.go
+++ b/track.go
@@ -1,76 +1,186 @@
 package webrtc
 
 import (
-	"crypto/rand"
-	"encoding/binary"
+	"fmt"
+	"sync"
 
-	"github.com/pions/rtcp"
 	"github.com/pions/rtp"
 	"github.com/pions/webrtc/pkg/media"
-	"github.com/pkg/errors"
 )
 
-// Track represents a track that is communicated
+const rtpOutboundMTU = 1400
+
+// Track represents a single media track
 type Track struct {
-	isRawRTP    bool
-	sampleInput chan media.Sample
-	rawInput    chan *rtp.Packet
-	rtcpInput   chan rtcp.Packet
+	mu sync.RWMutex
 
-	ID          string
-	PayloadType uint8
-	Kind        RTPCodecType
-	Label       string
-	SSRC        uint32
-	Codec       *RTPCodec
+	id          string
+	payloadType uint8
+	kind        RTPCodecType
+	label       string
+	ssrc        uint32
+	codec       *RTPCodec
 
-	Packets     <-chan *rtp.Packet
-	RTCPPackets <-chan rtcp.Packet
-
-	Samples chan<- media.Sample
-	RawRTP  chan<- *rtp.Packet
+	packetizer rtp.Packetizer
+	receiver   *RTPReceiver
+	senders    []*RTPSender
 }
 
-// NewRawRTPTrack initializes a new *Track configured to accept raw *rtp.Packet
-//
-// NB: If the source RTP stream is being broadcast to multiple tracks, each track
-// must receive its own copies of the source packets in order to avoid packet corruption.
-func NewRawRTPTrack(payloadType uint8, ssrc uint32, id, label string, codec *RTPCodec) (*Track, error) {
+// ID gets the ID of the track
+func (t *Track) ID() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.id
+}
+
+// PayloadType gets the PayloadType of the track
+func (t *Track) PayloadType() uint8 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.payloadType
+}
+
+// Kind gets the Kind of the track
+func (t *Track) Kind() RTPCodecType {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.kind
+}
+
+// Label gets the Label of the track
+func (t *Track) Label() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.label
+}
+
+// SSRC gets the SSRC of the track
+func (t *Track) SSRC() uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ssrc
+}
+
+// Codec gets the Codec of the track
+func (t *Track) Codec() *RTPCodec {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.codec
+}
+
+// Read reads data from the track. If this is a local track this will error
+func (t *Track) Read(b []byte) (n int, err error) {
+	t.mu.RLock()
+	if len(t.senders) != 0 {
+		t.mu.RUnlock()
+		return 0, fmt.Errorf("this is a local track and must not be read from")
+	}
+	r := t.receiver
+	t.mu.RUnlock()
+
+	return r.readRTP(b)
+}
+
+// ReadRTP is a convenience method that wraps Read and unmarshals for you
+func (t *Track) ReadRTP() (*rtp.Packet, error) {
+	b := make([]byte, receiveMTU)
+	i, err := t.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &rtp.Packet{}
+	if err := r.Unmarshal(b[:i]); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Write writes data to the track. If this is a remote track this will error
+func (t *Track) Write(b []byte) (n int, err error) {
+	t.mu.RLock()
+	if t.receiver != nil {
+		t.mu.RUnlock()
+		return 0, fmt.Errorf("this is a remote track and must not be written to")
+	}
+	senders := t.senders
+	t.mu.RUnlock()
+
+	for _, s := range senders {
+		if _, err := s.sendRTP(b); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(b), nil
+}
+
+// WriteSample packetizes and writes to the track
+func (t *Track) WriteSample(s media.Sample) error {
+	packets := t.packetizer.Packetize(s.Data, s.Samples)
+	for _, p := range packets {
+		buf, err := p.Marshal()
+		if err != nil {
+			return err
+		}
+		if _, err := t.Write(buf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteRTP writes RTP packets to the track
+func (t *Track) WriteRTP(p *rtp.Packet) error {
+	buf, err := p.Marshal()
+	if err != nil {
+		return err
+	}
+	if _, err := t.Write(buf); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewTrack initializes a new *Track
+func NewTrack(payloadType uint8, ssrc uint32, id, label string, codec *RTPCodec) (*Track, error) {
 	if ssrc == 0 {
-		return nil, errors.New("SSRC supplied to NewRawRTPTrack() must be non-zero")
+		return nil, fmt.Errorf("SSRC supplied to NewTrack() must be non-zero")
 	}
 
-	return &Track{
-		isRawRTP: true,
+	packetizer := rtp.NewPacketizer(
+		rtpOutboundMTU,
+		payloadType,
+		ssrc,
+		codec.Payloader,
+		rtp.NewRandomSequencer(),
+		codec.ClockRate,
+	)
 
-		ID:          id,
-		PayloadType: payloadType,
-		Kind:        codec.Type,
-		Label:       label,
-		SSRC:        ssrc,
-		Codec:       codec,
+	return &Track{
+		id:          id,
+		payloadType: payloadType,
+		kind:        codec.Type,
+		label:       label,
+		ssrc:        ssrc,
+		codec:       codec,
+		packetizer:  packetizer,
 	}, nil
 }
 
-// NewSampleTrack initializes a new *Track configured to accept media.Sample
-func NewSampleTrack(payloadType uint8, id, label string, codec *RTPCodec) (*Track, error) {
-	if codec == nil {
-		return nil, errors.New("codec supplied to NewSampleTrack() must not be nil")
+// determinePayloadType blocks and reads a single packet to determine the PayloadType for this Track
+// this is useful if we are dealing with a remote track and we can't announce it to the user until we know the payloadType
+func (t *Track) determinePayloadType() error {
+	r, err := t.ReadRTP()
+	if err != nil {
+		return err
 	}
 
-	buf := make([]byte, 4)
-	if _, err := rand.Read(buf); err != nil {
-		return nil, errors.New("failed to generate random value")
-	}
+	t.mu.Lock()
+	t.payloadType = r.PayloadType
+	defer t.mu.Unlock()
 
-	return &Track{
-		isRawRTP: false,
-
-		ID:          id,
-		PayloadType: payloadType,
-		Kind:        codec.Type,
-		Label:       label,
-		SSRC:        binary.LittleEndian.Uint32(buf),
-		Codec:       codec,
-	}, nil
+	return nil
 }


### PR DESCRIPTION
The Track API has been rewritten to remove Channels from the public API. This was done because we ran into the following issues.

* Use tight loops to read/write from Channels to exchange RTP/RTCP packets is more expensive then I realized
* We were unable to return errors when reading/write RTP or RTCP
* We were unable to close channels (or risk causing a panic if the user writes to them)

We also gained some unforeseen benefits moving to the new API.

* A Track can be added to multiple `PeerConnections` now. The most common use-case so far has been building SFUs, and this feature will reduce complexity for everyone. This also more closely follows the browser implementation of WebRTC.

# Changes

## RTPReceiver is now emitted via `onTrack`

### Before
```
peerConnection.OnTrack(func(track *webrtc.Track) {
})
```

### After
```
peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
})
```

## RTCP is now received via `RTPSender` and `RTPReceiver` instead of `Track`

### Before
```
peerConnection.OnTrack(func(track *webrtc.Track) {
    <-track.RTCPPackets
})
```

### After
```
peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
    pkt, header, err := receiver.ReadRTCP(make([]byte, 1400))
})
````

## RTP is now received via `Read` or `ReadRTP` on `Track`, instead of a channel

### Before
```
peerConnection.OnTrack(func(track *webrtc.Track) {
    <-track.Packets
})
```

### After
```
peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
    pkt, err := track.ReadRTP(make([]byte, 1400))
})
````


## RTP is now written via `Write`,  `WriteRTP` or `WriteSample` on `Track`, instead of send on a channel

### Before
```
peerConnection.OnTrack(func(track *webrtc.Track) {
    vp8Track.RawRTP <- &rtp.Packet{}
})
```

### After
```
peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
                       if i, err := track.WriteRTP(&rtp.Packet{})
})
````

## Raw and Sample tracks now share a constructor
The only behavior difference is that the user must supply a SSRC for Sample tracks. A random uint32 is all that should be needed in most cases.

### Before
```
peerConnection.NewRawRTPTrack(outboundPayloadType, outboundSSRC, "video", "pion")
pcOffer.NewSampleTrack(DefaultPayloadTypeVP8, "video", "pion")
```

### After
```
peerConnection.NewTrack(outboundPayloadType, outboundSSRC, "video", "pion")
```