### PR TITLE
Allow multiple Tracks with the same ID

### DIFF
--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1135,14 +1135,6 @@ func (pc *PeerConnection) AddTrack(track *Track) (*RTPSender, error) {
 	if pc.isClosed {
 		return nil, &rtcerr.InvalidStateError{Err: ErrConnectionClosed}
 	}
-	for _, transceiver := range pc.rtpTransceivers {
-		if transceiver.Sender.track == nil {
-			continue
-		}
-		if track.ID() == transceiver.Sender.track.ID() {
-			return nil, &rtcerr.InvalidAccessError{Err: ErrExistingTrack}
-		}
-	}
 	var transceiver *RTPTransceiver
 	for _, t := range pc.rtpTransceivers {
 		if !t.stopped &&


### PR DESCRIPTION
A PeerConnection is now able to mux multiple tracks. by removing this
resriction two tracks with the same ID are delivered to the client
muxed as one MediaStream.

Resolves #440