### PR TITLE
Docs: Build Janus example on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Will Watson](https://github.com/wwatson) - *Enable gocritic*
 * [Luke Curley](https://github.com/kixelated)
 * [Antoine Baché](https://github.com/Antonito) - *OGG Opus export*
+* [frank](https://github.com/feixiao) - *Building examples on OSX*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/examples/janus-gateway/README.md
+++ b/examples/janus-gateway/README.md
@@ -26,6 +26,27 @@ This example demonstrates how to stream to a Janus video-room using pion-WebRTC
 ### Running
 run `main.go` in `github.com/pions/webrtc/examples/janus-gateway/video-room`
 
+OSX
+```sh 
+brew install pkg-config
+https://gstreamer.freedesktop.org/data/pkg/osx/
+
+export PKG_CONFIG_PATH=/Library/Frameworks/GStreamer.framework/Versions/Current/lib/pkgconfig
+```
+Ubuntu
+```sh
+apt install pkg-config
+apt install libgstreamer*
+```
+
+Build
+```sh
+cd example/janus-gateway/video-room
+go build
+```
+
+
+
 If this worked you should see a test video in video-room `1234`
 
 This is the default demo-room that exists in the sample configs, and can quickly be accessed via the Janus demos.


### PR DESCRIPTION
Documented how to build the janus-gateway example on OSX.