### PR TITLE
Don't allow RTP codecs that violate RFC7587

### DIFF
--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	// Setup the codecs you want to use.
 	// We'll use a VP8 codec but you can also define your own
-	m.RegisterCodec(webrtc.NewRTPOpusCodec(webrtc.DefaultPayloadTypeOpus, 48000, 2))
+	m.RegisterCodec(webrtc.NewRTPOpusCodec(webrtc.DefaultPayloadTypeOpus, 48000))
 	m.RegisterCodec(webrtc.NewRTPVP8Codec(webrtc.DefaultPayloadTypeVP8, 90000))
 
 	// Create the API object with the MediaEngine

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -31,7 +31,7 @@ func (m *MediaEngine) RegisterCodec(codec *RTPCodec) uint8 {
 
 // RegisterDefaultCodecs is a helper that registers the default codecs supported by pions-webrtc
 func (m *MediaEngine) RegisterDefaultCodecs() {
-	m.RegisterCodec(NewRTPOpusCodec(DefaultPayloadTypeOpus, 48000, 2))
+	m.RegisterCodec(NewRTPOpusCodec(DefaultPayloadTypeOpus, 48000))
 	m.RegisterCodec(NewRTPG722Codec(DefaultPayloadTypeG722, 8000))
 	m.RegisterCodec(NewRTPVP8Codec(DefaultPayloadTypeVP8, 90000))
 	m.RegisterCodec(NewRTPH264Codec(DefaultPayloadTypeH264, 90000))
@@ -92,11 +92,11 @@ func NewRTPG722Codec(payloadType uint8, clockrate uint32) *RTPCodec {
 }
 
 // NewRTPOpusCodec is a helper to create an Opus codec
-func NewRTPOpusCodec(payloadType uint8, clockrate uint32, channels uint16) *RTPCodec {
+func NewRTPOpusCodec(payloadType uint8, clockrate uint32) *RTPCodec {
 	c := NewRTPCodec(RTPCodecTypeAudio,
 		Opus,
 		clockrate,
-		channels,
+		2, //According to RFC7587, Opus RTP streams must have exactly 2 channels.
 		"minptime=10;useinbandfec=1",
 		payloadType,
 		&codecs.OpusPayloader{})


### PR DESCRIPTION
The spec states that, to be packaged in RTP, Opus needs to have exactly 2 channels. If we remove that argument from the codec creation process, we're removing one place that's easy to get wrong.