### PR TITLE
Add support for batched RTP writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/pions/transport v0.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/net v0.0.0-20190227160552-c95aed5357e7
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2 h1:NwxKRvbkH5MsNkvOtPZi3/
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
+golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=

--- a/internal/ice/candidatepair.go
+++ b/internal/ice/candidatepair.go
@@ -80,6 +80,10 @@ func (p *candidatePair) Write(b []byte) (int, error) {
 	return p.local.writeTo(b, p.remote)
 }
 
+func (p *candidatePair) WriteBatch(packets [][]byte) (int, error) {
+	return p.local.writeBatchTo(packets, p.remote)
+}
+
 // keepaliveCandidate sends a STUN Binding Indication to the remote candidate
 func (a *Agent) keepaliveCandidate(local, remote *Candidate) {
 	msg, err := stun.Build(stun.ClassIndication, stun.MethodBinding, stun.GenerateTransactionID(),

--- a/internal/mux/connection.go
+++ b/internal/mux/connection.go
@@ -1,0 +1,51 @@
+package mux
+
+import (
+	"net"
+)
+
+type connection interface {
+	net.Conn
+
+	WriteBatch(packets [][]byte) (n int, err error)
+	ReadBatch(packets [][]byte) (n int, err error)
+}
+
+type simpleBatcher struct {
+	net.Conn
+}
+
+func (sb simpleBatcher) WriteBatch(packets [][]byte) (n int, err error) {
+	for i, packet := range packets {
+		_, err = sb.Write(packet)
+		if err != nil {
+			return i, err
+		}
+	}
+
+	return len(packets), nil
+}
+
+func (sb simpleBatcher) ReadBatch(packets [][]byte) (n int, err error) {
+	if len(packets) == 0 {
+		return 0, nil
+	}
+
+	_, err = sb.Read(packets[0])
+	if err != nil {
+		return 0, err
+	}
+
+	return 1, nil
+}
+
+func newConnection(conn net.Conn) (c connection) {
+	// See if the connection already obeys the interface, giving us full batching support.
+	c, ok := conn.(connection)
+	if ok {
+		return c
+	}
+
+	// Otherwise use a wrapper that translates the batch calls into single reads/writes
+	return simpleBatcher{conn}
+}

--- a/internal/mux/endpoint.go
+++ b/internal/mux/endpoint.go
@@ -47,9 +47,18 @@ func (e *Endpoint) Read(p []byte) (int, error) {
 	}
 }
 
+func (e *Endpoint) ReadBatch(packets [][]byte) (n int, err error) {
+	return 0, errors.New("unimplemented")
+}
+
 // Write writes len(p) bytes to the underlying conn
 func (e *Endpoint) Write(p []byte) (n int, err error) {
 	return e.mux.nextConn.Write(p)
+}
+
+// WriteBatch writes multiple packets to the underlying conn
+func (e *Endpoint) WriteBatch(packets [][]byte) (n int, err error) {
+	return e.mux.nextConn.WriteBatch(packets)
 }
 
 // LocalAddr is a stub

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -9,7 +9,7 @@ import (
 // Mux allows multiplexing
 type Mux struct {
 	lock       sync.RWMutex
-	nextConn   net.Conn
+	nextConn   connection
 	endpoints  map[*Endpoint]MatchFunc
 	bufferSize int
 	closedCh   chan struct{}
@@ -18,7 +18,7 @@ type Mux struct {
 // NewMux creates a new Mux
 func NewMux(conn net.Conn, bufferSize int) *Mux {
 	m := &Mux{
-		nextConn:   conn,
+		nextConn:   newConnection(conn),
 		endpoints:  make(map[*Endpoint]MatchFunc),
 		bufferSize: bufferSize,
 		closedCh:   make(chan struct{}),

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1009,13 +1009,11 @@ func (pc *PeerConnection) drainSRTP() {
 			go func() {
 				rtpBuf := make([]byte, receiveMTU)
 				for {
-					_, rtpHeader, err := r.ReadRTP(rtpBuf)
+					_, _, err := r.ReadRTP(rtpBuf)
 					if err != nil {
 						pcLog.Warnf("Failed to read, drainSRTP done for: %v %d \n", err, ssrc)
 						return
 					}
-
-					pcLog.Debugf("got RTP: %+v", rtpHeader)
 				}
 			}()
 		}


### PR DESCRIPTION
Depends on SRTP supporting the same batched interface.

The only API change is that `WriteRTP` can now take multiple packets at
once instead of a single one. This lets the API consumer decide what
level of batching to perform.

`WriteSample` will automatically batch packets into a single send.

Under the hood, we use the `sendmmsg` syscall if supported.
Other platforms will default to multiple `sendmsg` calls and won't see a
performance difference. This is faster because it avoids extra
transitions between kernel and user-space which has a significant cost
especially after spectre patches.

For my write-heavy application, this improved performance by 1.4x.