### PR TITLE
Issue 460

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -26,7 +26,7 @@ type ICEGatherer struct {
 // This constructor is part of the ORTC API. It is not
 // meant to be used together with the basic WebRTC API.
 func (api *API) NewICEGatherer(opts ICEGatherOptions) (*ICEGatherer, error) {
-	validatedServers := []*ice.URL{}
+	var validatedServers []*ice.URL
 	if len(opts.ICEServers) > 0 {
 		for _, server := range opts.ICEServers {
 			url, err := server.validate()
@@ -62,6 +62,15 @@ func (g *ICEGatherer) Gather() error {
 		PortMax:           g.api.settingEngine.ephemeralUDP.PortMax,
 		ConnectionTimeout: g.api.settingEngine.timeout.ICEConnection,
 		KeepaliveInterval: g.api.settingEngine.timeout.ICEKeepalive,
+	}
+
+	requestedNetworkTypes := g.api.settingEngine.candidates.ICENetworkTypes
+	if len(requestedNetworkTypes) == 0 {
+		requestedNetworkTypes = supportedNetworkTypes
+	}
+
+	for _, typ := range requestedNetworkTypes {
+		config.NetworkTypes = append(config.NetworkTypes, ice.NetworkType(typ))
 	}
 
 	agent, err := ice.NewAgent(config)

--- a/internal/ice/networktype.go
+++ b/internal/ice/networktype.go
@@ -30,13 +30,13 @@ const (
 	// NetworkTypeUDP4 indicates UDP over IPv4.
 	NetworkTypeUDP4 NetworkType = iota + 1
 
-	// NetworkTypeUDP6 indicates UDP over IPv4.
+	// NetworkTypeUDP6 indicates UDP over IPv6.
 	NetworkTypeUDP6
 
 	// NetworkTypeTCP4 indicates TCP over IPv4.
 	NetworkTypeTCP4
 
-	// NetworkTypeTCP6 indicates TCP over IPv4.
+	// NetworkTypeTCP6 indicates TCP over IPv6.
 	NetworkTypeTCP6
 )
 
@@ -73,6 +73,28 @@ func (t NetworkType) IsReliable() bool {
 	case NetworkTypeUDP4, NetworkTypeUDP6:
 		return false
 	case NetworkTypeTCP4, NetworkTypeTCP6:
+		return true
+	}
+	return false
+}
+
+// IsIPv4 returns whether the network type is IPv4 or not.
+func (t NetworkType) IsIPv4() bool {
+	switch t {
+	case NetworkTypeUDP4, NetworkTypeTCP4:
+		return true
+	case NetworkTypeUDP6, NetworkTypeTCP6:
+		return false
+	}
+	return false
+}
+
+// IsIPv6 returns whether the network type is IPv6 or not.
+func (t NetworkType) IsIPv6() bool {
+	switch t {
+	case NetworkTypeUDP4, NetworkTypeTCP4:
+		return false
+	case NetworkTypeUDP6, NetworkTypeTCP6:
 		return true
 	}
 	return false

--- a/internal/ice/transport_test.go
+++ b/internal/ice/transport_test.go
@@ -33,7 +33,7 @@ func testTimeout(t *testing.T, c *Conn, timeout time.Duration) {
 		})
 
 		if err != nil {
-			//we should never get here.
+			// we should never get here.
 			panic(err)
 		}
 
@@ -59,7 +59,7 @@ func TestTimeout(t *testing.T) {
 	err := cb.Close()
 
 	if err != nil {
-		//we should never get here.
+		// we should never get here.
 		panic(err)
 	}
 
@@ -69,7 +69,7 @@ func TestTimeout(t *testing.T) {
 	err = cb.Close()
 
 	if err != nil {
-		//we should never get here.
+		// we should never get here.
 		panic(err)
 	}
 
@@ -81,13 +81,13 @@ func TestReadClosed(t *testing.T) {
 
 	err := ca.Close()
 	if err != nil {
-		//we should never get here.
+		// we should never get here.
 		panic(err)
 	}
 
 	err = cb.Close()
 	if err != nil {
-		//we should never get here.
+		// we should never get here.
 		panic(err)
 	}
 
@@ -191,7 +191,10 @@ func pipe() (*Conn, *Conn) {
 	aNotifier, aConnected := onConnected()
 	bNotifier, bConnected := onConnected()
 
-	aAgent, err := NewAgent(&AgentConfig{Urls: urls})
+	aAgent, err := NewAgent(&AgentConfig{
+		Urls:         urls,
+		NetworkTypes: supportedNetworkTypes,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -200,7 +203,10 @@ func pipe() (*Conn, *Conn) {
 		panic(err)
 	}
 
-	bAgent, err := NewAgent(&AgentConfig{Urls: urls})
+	bAgent, err := NewAgent(&AgentConfig{
+		Urls:         urls,
+		NetworkTypes: supportedNetworkTypes,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -225,7 +231,12 @@ func pipeWithTimeout(iceTimeout time.Duration, iceKeepalive time.Duration) (*Con
 	aNotifier, aConnected := onConnected()
 	bNotifier, bConnected := onConnected()
 
-	aAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &iceTimeout, KeepaliveInterval: &iceKeepalive})
+	aAgent, err := NewAgent(&AgentConfig{
+		Urls:              urls,
+		ConnectionTimeout: &iceTimeout,
+		KeepaliveInterval: &iceKeepalive,
+		NetworkTypes:      supportedNetworkTypes,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -234,7 +245,12 @@ func pipeWithTimeout(iceTimeout time.Duration, iceKeepalive time.Duration) (*Con
 		panic(err)
 	}
 
-	bAgent, err := NewAgent(&AgentConfig{Urls: urls, ConnectionTimeout: &iceTimeout, KeepaliveInterval: &iceKeepalive})
+	bAgent, err := NewAgent(&AgentConfig{
+		Urls:              urls,
+		ConnectionTimeout: &iceTimeout,
+		KeepaliveInterval: &iceKeepalive,
+		NetworkTypes:      supportedNetworkTypes,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/networktype.go
+++ b/networktype.go
@@ -1,0 +1,67 @@
+package webrtc
+
+import (
+	"fmt"
+)
+
+var supportedNetworkTypes = []NetworkType{
+	NetworkTypeUDP4,
+	NetworkTypeUDP6,
+	// NetworkTypeTCP4, // Not supported yet
+	// NetworkTypeTCP6, // Not supported yet
+}
+
+// NetworkType represents the type of network
+type NetworkType int
+
+const (
+	// NetworkTypeUDP4 indicates UDP over IPv4.
+	NetworkTypeUDP4 NetworkType = iota + 1
+
+	// NetworkTypeUDP6 indicates UDP over IPv6.
+	NetworkTypeUDP6
+
+	// NetworkTypeTCP4 indicates TCP over IPv4.
+	NetworkTypeTCP4
+
+	// NetworkTypeTCP6 indicates TCP over IPv6.
+	NetworkTypeTCP6
+)
+
+// This is done this way because of a linter.
+const (
+	networkTypeUDP4Str = "udp4"
+	networkTypeUDP6Str = "udp6"
+	networkTypeTCP4Str = "tcp4"
+	networkTypeTCP6Str = "tcp6"
+)
+
+func (t NetworkType) String() string {
+	switch t {
+	case NetworkTypeUDP4:
+		return networkTypeUDP4Str
+	case NetworkTypeUDP6:
+		return networkTypeUDP6Str
+	case NetworkTypeTCP4:
+		return networkTypeTCP4Str
+	case NetworkTypeTCP6:
+		return networkTypeTCP6Str
+	default:
+		return ErrUnknownType.Error()
+	}
+}
+
+func newNetworkType(raw string) (NetworkType, error) {
+	switch raw {
+	case networkTypeUDP4Str:
+		return NetworkTypeUDP4, nil
+	case networkTypeUDP6Str:
+		return NetworkTypeUDP6, nil
+	case networkTypeTCP4Str:
+		return NetworkTypeTCP4, nil
+	case networkTypeTCP6Str:
+		return NetworkTypeTCP6, nil
+	default:
+		return NetworkType(Unknown), fmt.Errorf("unknown network type: %s", raw)
+	}
+}

--- a/networktype_test.go
+++ b/networktype_test.go
@@ -1,0 +1,54 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkType_String(t *testing.T) {
+	testCases := []struct {
+		cType          NetworkType
+		expectedString string
+	}{
+		{NetworkType(Unknown), unknownStr},
+		{NetworkTypeUDP4, "udp4"},
+		{NetworkTypeUDP6, "udp6"},
+		{NetworkTypeTCP4, "tcp4"},
+		{NetworkTypeTCP6, "tcp6"},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(t,
+			testCase.expectedString,
+			testCase.cType.String(),
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}
+
+func TestNetworkType(t *testing.T) {
+	testCases := []struct {
+		typeString   string
+		shouldFail   bool
+		expectedType NetworkType
+	}{
+		{unknownStr, true, NetworkType(Unknown)},
+		{"udp4", false, NetworkTypeUDP4},
+		{"udp6", false, NetworkTypeUDP6},
+		{"tcp4", false, NetworkTypeTCP4},
+		{"tcp6", false, NetworkTypeTCP6},
+	}
+
+	for i, testCase := range testCases {
+		actual, err := newNetworkType(testCase.typeString)
+		if (err != nil) != testCase.shouldFail {
+			t.Error(err)
+		}
+		assert.Equal(t,
+			testCase.expectedType,
+			actual,
+			"testCase: %d %v", i, testCase,
+		)
+	}
+}

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -230,6 +230,7 @@ func (pc *PeerConnection) initConfiguration(configuration Configuration) error {
 		}
 		pc.configuration.ICEServers = configuration.ICEServers
 	}
+
 	return nil
 }
 
@@ -468,7 +469,6 @@ func (pc *PeerConnection) CreateOffer(options *OfferOptions) (SessionDescription
 func (pc *PeerConnection) createICEGatherer() (*ICEGatherer, error) {
 	g, err := pc.api.NewICEGatherer(ICEGatherOptions{
 		ICEServers: pc.configuration.ICEServers,
-		// TODO: GatherPolicy
 	})
 	if err != nil {
 		return nil, err

--- a/settingengine.go
+++ b/settingengine.go
@@ -21,6 +21,9 @@ type SettingEngine struct {
 		ICEConnection *time.Duration
 		ICEKeepalive  *time.Duration
 	}
+	candidates struct {
+		ICENetworkTypes []NetworkType
+	}
 }
 
 // DetachDataChannels enables detaching data channels. When enabled
@@ -48,4 +51,10 @@ func (e *SettingEngine) SetEphemeralUDPPortRange(portMin, portMax uint16) error 
 	e.ephemeralUDP.PortMin = portMin
 	e.ephemeralUDP.PortMax = portMax
 	return nil
+}
+
+// SetNetworkTypes configures what types of candidate networks are supported
+// during local and server reflexive gathering.
+func (e *SettingEngine) SetNetworkTypes(candidateTypes []NetworkType) {
+	e.candidates.ICENetworkTypes = candidateTypes
 }


### PR DESCRIPTION
This is a temporary solution. We should not have this lying around normally. Once v2.0 is out and fixes the underlying issue with specific ipv6 issues for the server reflexive candidates, we should remove the support for this.

Resolves #460 