### PR TITLE
Use args instead of stdin in save-to-disk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Antoine Baché](https://github.com/Antonito) - *OGG Opus export*
 * [frank](https://github.com/feixiao) - *Building examples on OSX*
 * [mxmCherry](https://github.com/mxmCherry)
+* [Ante Lucic](https://github.com/alucic)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/examples/save-to-disk/README.md
+++ b/examples/save-to-disk/README.md
@@ -1,27 +1,40 @@
 # save-to-disk
-save-to-disk is a simple application that shows how to record your webcam using pion-WebRTC and save to disk.
+This is a simple application that captures video and audio from your computer and save it to disk using pion-WebRTC. This example involves two peers, your browser and `save-to-disk` application. Peers have to exchange Session Descriptions in order to establish a connection.
 
 ## Instructions
-### Download save-to-disk
+There are three key parts in this example:
+* The first part is getting Browsers Session Description
+* The second part is getting `save-to-disk` Session Description
+* The third part is starting the session and sending video and audio streams from browser to `save-to-disk` application
+
+### Part one - getting browser's Session Description
+Browser code lives inside `jsfiddle` directory but you can run it on this [jsfiddle.net](https://jsfiddle.net/dyj8qpek/19/) link.
+
+Browser will prompt you that the page needs permissions to acces your video and audio device. Once you grant permissions, you should be able to see video from your webcam on the jsfiddle page.
+
+The page has two input fields and a video element. The first input field `Browser base64 Session Description` should be prepopulated. The second input field `Golang base64 Session Description` will be empty.
+
+Copy contents of `Browser base64 Session Description` input field.
+
+### Part two - getting save-to-disk Session Description
+Make sure you have `save-to-disk` example on your machine
 ```
 go get github.com/pions/webrtc/examples/save-to-disk
 ```
 
-### Open save-to-disk example page
-[jsfiddle.net](https://jsfiddle.net/dyj8qpek/19/) you should see your Webcam, two text-areas and a 'Start Session' button
+Change directory to be `save-to-disk` directory
+```
+cd $GOPATH/src/github.com/pions/webrtc/examples/save-to-disk
+```
 
-### Run save-to-disk, with your browsers SessionDescription as stdin
-In the jsfiddle the top textarea is your browser, copy that and:
-#### Linux/macOS
-Run `echo $BROWSER_SDP | save-to-disk`
-#### Windows
-1. Paste the SessionDescription into a file.
-1. Run `save-to-disk < my_file`
+When running this example, paste Browser's Session Description as the first argument:
+```
+go run main.go PASTE_BROWSER_SESSION_DESCRIPTION_HERE
+```
+The application will print out `save-to-disk` Session Description. Copy it and paste it in the jsfiddle `Golang base64 Session Description` input field.
 
-### Input save-to-disk's SessionDescription into your browser
-Copy the text that `save-to-disk` just emitted and copy into second text area
-
-### Hit 'Start Session' in jsfiddle, enjoy your video!
-In the folder you ran `save-to-disk` you should now have a file `output-1.ivf` play with your video player of choice!
+### Part three - starting the session
+Now both peers know about each other and they are ready to connect. Go to the jsfiddle page and hit 'Start Session'.
+Your video and audio will be sent from the browser to `save-to-disk` application. When you're done, stop `save-to-disk` and in the directory you ran it you should have two files `output.ivf` and `output.opus`
 
 Congrats, you have used pion-WebRTC! Now start building something cool

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pions/rtcp"
@@ -33,6 +34,14 @@ func saveToDisk(i media.Writer, track *webrtc.Track) {
 }
 
 func main() {
+
+	if len(os.Args) < 2 {
+		fmt.Println("Missing Browser Session Description - Usage: go run main.go PASTE_BROWSER_SESSION_DESCRIPTION_HERE")
+		os.Exit(1)
+	}
+
+	browserSessionDescription := os.Args[1]
+
 	// Create a MediaEngine object to configure the supported codec
 	m := webrtc.MediaEngine{}
 
@@ -100,9 +109,9 @@ func main() {
 		fmt.Printf("Connection State has changed %s \n", connectionState.String())
 	})
 
-	// Wait for the offer to be pasted
+	// Decode browserSessionDescription
 	offer := webrtc.SessionDescription{}
-	signal.Decode(signal.MustReadStdin(), &offer)
+	signal.Decode(browserSessionDescription, &offer)
 
 	// Set the remote SessionDescription
 	err = peerConnection.SetRemoteDescription(offer)
@@ -123,7 +132,7 @@ func main() {
 	}
 
 	// Output the answer in base64 so we can paste it in browser
-	fmt.Println(signal.Encode(answer))
+	fmt.Printf("\nPaste this in 'Golang base64 Session Description' input field in the browser \n%s\n", signal.Encode(answer))
 
 	// Block forever
 	select {}


### PR DESCRIPTION
When running `save-to-disk` example, there are two sets of instructions, one for Windows and the other for Linux/macOS. This PR is trying to bridge the platform gap by using arguments instead of `stdin` for getting Browser's Session Description.

* pass in browser session as an argument instead of stdin
* update readme file with additional information

```diff
- echo BROWSER_SDP | save-to-disk
+ save-to-disk BROWSER_SDP
```