### PR TITLE
Fix deadlock in DTLS shutdown

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,10 +1,13 @@
 package mux
 
 import (
-	"fmt"
 	"net"
 	"sync"
+
+	"github.com/pions/webrtc/pkg/logging"
 )
+
+var muxLog = logging.NewScopedLogger("mux")
 
 // Mux allows multiplexing
 type Mux struct {
@@ -100,7 +103,7 @@ func (m *Mux) dispatch(buf []byte) {
 	m.lock.Unlock()
 
 	if endpoint == nil {
-		fmt.Printf("Warning: mux: no endpoint for packet starting with %d\n", buf[0])
+		muxLog.Warnf("Warning: mux: no endpoint for packet starting with %d\n", buf[0])
 		return
 	}
 

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1334,8 +1334,8 @@ func (pc *PeerConnection) Close() error {
 	//    Conn if one of the endpoints is closed down. To
 	//    continue the chain the Mux has to be closed.
 
-	for _, t := range pc.rtpTransceivers {
-		if err := t.Stop(); err != nil {
+	if pc.iceTransport != nil {
+		if err := pc.iceTransport.Stop(); err != nil {
 			closeErrs = append(closeErrs, err)
 		}
 	}
@@ -1350,10 +1350,8 @@ func (pc *PeerConnection) Close() error {
 		}
 	}
 
-	// TODO: Close DTLS?
-
-	if pc.iceTransport != nil {
-		if err := pc.iceTransport.Stop(); err != nil {
+	for _, t := range pc.rtpTransceivers {
+		if err := t.Stop(); err != nil {
 			closeErrs = append(closeErrs, err)
 		}
 	}

--- a/peerconnection_media_test.go
+++ b/peerconnection_media_test.go
@@ -289,10 +289,8 @@ func TestPeerConnection_Media_Sender_Transports_OnSelectedCandidatePairChange(t 
 
 	pcAnswer.OnICEConnectionStateChange(func(iceState ICEConnectionState) {
 		if iceState == ICEConnectionStateConnected {
-			go func() {
-				time.Sleep(3 * time.Second) // TODO PeerConnection.Close() doesn't block for all subsystems
-				close(iceComplete)
-			}()
+			time.Sleep(3 * time.Second) // TODO PeerConnection.Close() doesn't block for all subsystems
+			close(iceComplete)
 		}
 	})
 


### PR DESCRIPTION
DTLS shutdown deadlocks if Close is called before startup completes,
because the DTLS connection hasn't finished yet we don't have handles
to close anything.

This updates DTLS to follow how SCTP is shutdown, by shutting down the
nextConn (ICE in this case) we can shutdown the subsystem. By closing
ICE first, DTLS (and then SCTP) close properly no matter what state
they are in.