### PR TITLE
Update janus-gateway/video-room with keepalive

### DIFF
--- a/examples/janus-gateway/README.md
+++ b/examples/janus-gateway/README.md
@@ -27,7 +27,7 @@ This example demonstrates how to stream to a Janus video-room using pion-WebRTC
 run `main.go` in `github.com/pions/webrtc/examples/janus-gateway/video-room`
 
 OSX
-```sh 
+```sh
 brew install pkg-config
 https://gstreamer.freedesktop.org/data/pkg/osx/
 

--- a/examples/janus-gateway/video-room/main.go
+++ b/examples/janus-gateway/video-room/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"time"
 
 	janus "github.com/notedit/janus-go"
 	"github.com/pions/webrtc"
@@ -98,6 +99,16 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	go func() {
+		for {
+			if _, keepAliveErr := session.KeepAlive(); err != nil {
+				panic(keepAliveErr)
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}()
 
 	go watchHandle(handle)
 


### PR DESCRIPTION
Example wasn't sending keep-alives, causing Janus to eventually
end the session even if we weren't done sending