### PR TITLE
Add feedback support to SDP generation.

### DIFF
--- a/mediaengine.go
+++ b/mediaengine.go
@@ -197,10 +197,11 @@ func NewRTPCodec(
 
 // RTPCodecCapability provides information about codec capabilities.
 type RTPCodecCapability struct {
-	MimeType    string
-	ClockRate   uint32
-	Channels    uint16
-	SDPFmtpLine string
+	MimeType     string
+	ClockRate    uint32
+	Channels     uint16
+	SDPFmtpLine  string
+	RTCPFeedback []RTCPFeedback
 }
 
 // RTPHeaderExtensionCapability is used to define a RFC5285 RTP header extension supported by the codec.

--- a/peerconnection.go
+++ b/peerconnection.go
@@ -1373,6 +1373,10 @@ func (pc *PeerConnection) addRTPMediaSection(d *sdp.SessionDescription, codecTyp
 
 	for _, codec := range pc.api.mediaEngine.getCodecsByKind(codecType) {
 		media.WithCodec(codec.PayloadType, codec.Name, codec.ClockRate, codec.Channels, codec.SDPFmtpLine)
+
+		for _, feedback := range codec.RTPCodecCapability.RTCPFeedback {
+			media.WithValueAttribute("rtcp-fb", fmt.Sprintf("%d %s %s", codec.PayloadType, feedback.Type, feedback.Parameter))
+		}
 	}
 
 	weSend := false

--- a/rtcpfeedback.go
+++ b/rtcpfeedback.go
@@ -1,0 +1,14 @@
+package webrtc
+
+// RTCPFeedback signals the connection to use additional RTCP packet types.
+// https://draft.ortc.org/#dom-rtcrtcpfeedback
+type RTCPFeedback struct {
+	// Type is the type of feedback.
+	// see: https://draft.ortc.org/#dom-rtcrtcpfeedback
+	// valid: ack, ccm, nack, goog-remb, transport-cc
+	Type string
+
+	// The parameter value depends on the type.
+	// For example, type="nack" parameter="pli" will send Picture Loss Indicator packets.
+	Parameter string
+}


### PR DESCRIPTION
These are optional RTCP packets that will be sent if enabled in the
offer/answer. They currently all default to disabled because
pions/webrtc has no built-in support to handle these packets. We can
change the default values in the future but until then, they use too
much bandwidth.

The API may be controversial because I'm extending the WebRTC spec. I
don't think that there's any issue providing a superset of the API. We
already do it today by adding methods to RTPSender, and it makes the
interface a lot nicer.
