### PR TITLE
Optimize ice.Agent.getBestPair()

### DIFF
--- a/internal/ice/agent.go
+++ b/internal/ice/agent.go
@@ -79,6 +79,8 @@ type Agent struct {
 
 	buffer *packetio.Buffer
 
+	runMutex sync.Mutex
+
 	// State for closing
 	done chan struct{}
 	err  atomicError
@@ -178,7 +180,7 @@ func NewAgent(config *AgentConfig) (*Agent, error) {
 
 // OnConnectionStateChange sets a handler that is fired when the connection state changes
 func (a *Agent) OnConnectionStateChange(f func(ConnectionState)) error {
-	return a.run(func(agent *Agent) {
+	return a.runInline(func(agent *Agent) {
 		agent.onConnectionStateChangeHdlr = f
 	})
 }
@@ -186,7 +188,7 @@ func (a *Agent) OnConnectionStateChange(f func(ConnectionState)) error {
 // OnSelectedCandidatePairChange sets a handler that is fired when the final candidate
 // pair is selected
 func (a *Agent) OnSelectedCandidatePairChange(f func(*Candidate, *Candidate)) error {
-	return a.run(func(agent *Agent) {
+	return a.runInline(func(agent *Agent) {
 		agent.onSelectedCandidatePairChangeHdlr = f
 	})
 }
@@ -455,6 +457,21 @@ func (a *Agent) run(t task) error {
 		return a.getErr()
 	case a.taskChan <- t:
 	}
+
+	return nil
+}
+
+func (a *Agent) runInline(t task) error {
+	a.runMutex.Lock()
+	defer a.runMutex.Unlock()
+
+	err := a.ok()
+	if err != nil {
+		return err
+	}
+
+	t(a)
+
 	return nil
 }
 
@@ -462,18 +479,26 @@ func (a *Agent) taskLoop() {
 	for {
 		select {
 		case <-a.connectivityChan:
-			if a.validateSelectedPair() {
-				a.log.Trace("checking keepalive")
-				a.checkKeepalive()
-			} else {
-				a.log.Trace("pinging all candidates")
-				a.pingAllCandidates()
+			// Returns err if the agent is done.
+			err := a.runInline(func(a *Agent) {
+				if a.validateSelectedPair() {
+					a.log.Trace("checking keepalive")
+					a.checkKeepalive()
+				} else {
+					a.log.Trace("pinging all candidates")
+					a.pingAllCandidates()
+				}
+			})
+
+			if err != nil {
+				return
 			}
-
 		case t := <-a.taskChan:
-			// Run the task
-			t(a)
-
+			// Returns err if the agent is done.
+			err = a.runInline(t)
+			if err != nil {
+				return err
+			}
 		case <-a.done:
 			return
 		}
@@ -551,21 +576,18 @@ func (a *Agent) addRemoteCandidate(c *Candidate) {
 }
 
 // GetLocalCandidates returns the local candidates
-func (a *Agent) GetLocalCandidates() ([]*Candidate, error) {
-	res := make(chan []*Candidate)
-
-	err := a.run(func(agent *Agent) {
-		var candidates []*Candidate
+func (a *Agent) GetLocalCandidates() (candidates []*Candidate, err error) {
+	err = a.runInline(func(agent *Agent) {
 		for _, set := range agent.localCandidates {
 			candidates = append(candidates, set...)
 		}
-		res <- candidates
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	return <-res, nil
+	return candidates, nil
 }
 
 // GetLocalUserCredentials returns the local user credentials
@@ -575,11 +597,7 @@ func (a *Agent) GetLocalUserCredentials() (frag string, pwd string) {
 
 // Close cleans up the Agent
 func (a *Agent) Close() error {
-	done := make(chan struct{})
-	err := a.run(func(agent *Agent) {
-		defer func() {
-			close(done)
-		}()
+	return a.runInline(func(agent *Agent) {
 		agent.err.Store(ErrClosed)
 		close(agent.done)
 
@@ -608,13 +626,6 @@ func (a *Agent) Close() error {
 			a.log.Warnf("failed to close buffer: %v", err)
 		}
 	})
-	if err != nil {
-		return err
-	}
-
-	<-done
-
-	return nil
 }
 
 func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) *Candidate {
@@ -775,30 +786,25 @@ func (a *Agent) noSTUNSeen(local *Candidate, remote net.Addr) {
 	}
 }
 
-func (a *Agent) getBestPair() (*candidatePair, error) {
-	res := make(chan *candidatePair)
-
-	err := a.run(func(agent *Agent) {
+func (a *Agent) getBestPair() (res *candidatePair, err error) {
+	err = a.runInline(func(agent *Agent) {
 		if agent.selectedPair != nil {
-			res <- agent.selectedPair
+			res = agent.selectedPair
 			return
 		}
 		for _, p := range agent.validPairs {
-			res <- p
+			res = p
 			return
 		}
-		res <- nil
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	out := <-res
-
-	if out == nil {
+	if res == nil {
 		return nil, errors.New("no Valid Candidate Pairs Available")
 	}
 
-	return out, nil
+	return res, nil
 }

--- a/internal/ice/agent_test.go
+++ b/internal/ice/agent_test.go
@@ -312,3 +312,22 @@ func TestHandlePeerReflexive(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkGetBestPair(b *testing.B) {
+	a, err := NewAgent(&AgentConfig{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// There are no pairs so this will error.
+		_, _ = a.getBestPair()
+	}
+
+	err = a.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
This function should be trivial but profiles show it taking 3-5% of my
application's CPU time. The problem is the constant creation of a
channel for message passing. This function is called by srtp.WriteRTP
for each packet, so it adds up.

My fix was to create a `runInner` function that utilizies a mutex. I
wanted to convert all `run` functions to `runInner` but the code
occasionally deadlocks in unit tests. The package is definitely a
candidate for a rewrite.

```
name           old time/op    new time/op    delta
GetBestPair-8     915ns ± 3%      80ns ± 4%  -91.23%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
GetBestPair-8      128B ± 0%       16B ± 0%  -87.50%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
GetBestPair-8      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
```