### PR TITLE
Improve build tags for Wasm

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 // API bundles the global funcions of the WebRTC and ORTC API.

--- a/certificate.go
+++ b/certificate.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/configuration_js.go
+++ b/configuration_js.go
@@ -1,4 +1,4 @@
-// +build !js
+// +build js,wasm
 
 package webrtc
 
@@ -31,18 +31,8 @@ type Configuration struct {
 	// unless it can be successfully authenticated with the provided name.
 	PeerIdentity string
 
-	// Certificates describes a set of certificates that the PeerConnection
-	// uses to authenticate. Valid values for this parameter are created
-	// through calls to the GenerateCertificate function. Although any given
-	// DTLS connection will use only one certificate, this attribute allows the
-	// caller to provide multiple certificates that support different
-	// algorithms. The final certificate will be selected based on the DTLS
-	// handshake, which establishes which certificates are allowed. The
-	// PeerConnection implementation selects which of the certificates is
-	// used for a given connection; how certificates are selected is outside
-	// the scope of this specification. If this value is absent, then a default
-	// set of certificates is generated for each PeerConnection instance.
-	Certificates []Certificate
+	// Certificates are not supported in the JavaScript/Wasm bindings.
+	// Certificates []Certificate
 
 	// ICECandidatePoolSize describes the size of the prefetched ICE pool.
 	ICECandidatePoolSize uint8

--- a/datachannel_js.go
+++ b/datachannel_js.go
@@ -1,4 +1,4 @@
-// +build js
+// +build js,wasm
 
 package webrtc
 

--- a/examples/data-channels/jsfiddle/main.go
+++ b/examples/data-channels/jsfiddle/main.go
@@ -1,4 +1,4 @@
-// +build js
+// +build js,wasm
 
 package main
 

--- a/icegatherer.go
+++ b/icegatherer.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/iceserver.go
+++ b/iceserver.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/iceserver_js.go
+++ b/iceserver_js.go
@@ -1,0 +1,63 @@
+// +build js,wasm
+
+package webrtc
+
+import (
+	"errors"
+
+	"github.com/pions/webrtc/internal/ice"
+)
+
+// ICEServer describes a single STUN and TURN server that can be used by
+// the ICEAgent to establish a connection with a peer.
+type ICEServer struct {
+	URLs     []string
+	Username string
+	// Note: Credential and CredentialType are not supported.
+	// Credential     interface{}
+	// CredentialType ICECredentialType
+}
+
+func (s ICEServer) parseURL(i int) (*ice.URL, error) {
+	return ice.ParseURL(s.URLs[i])
+}
+
+func (s ICEServer) validate() ([]*ice.URL, error) {
+	urls := []*ice.URL{}
+
+	for i := range s.URLs {
+		url, err := s.parseURL(i)
+		if err != nil {
+			return nil, err
+		}
+
+		if url.Scheme == ice.SchemeTypeTURN || url.Scheme == ice.SchemeTypeTURNS {
+			// // https://www.w3.org/TR/webrtc/#set-the-configuration (step #11.3.2)
+			// if s.Username == "" || s.Credential == nil {
+			// 	return nil, &rtcerr.InvalidAccessError{Err: ErrNoTurnCredencials}
+			// }
+
+			// switch s.CredentialType {
+			// case ICECredentialTypePassword:
+			// 	// https://www.w3.org/TR/webrtc/#set-the-configuration (step #11.3.3)
+			// 	if _, ok := s.Credential.(string); !ok {
+			// 		return nil, &rtcerr.InvalidAccessError{Err: ErrTurnCredencials}
+			// 	}
+
+			// case ICECredentialTypeOauth:
+			// 	// https://www.w3.org/TR/webrtc/#set-the-configuration (step #11.3.4)
+			// 	if _, ok := s.Credential.(OAuthCredential); !ok {
+			// 		return nil, &rtcerr.InvalidAccessError{Err: ErrTurnCredencials}
+			// 	}
+
+			// default:
+			// 	return nil, &rtcerr.InvalidAccessError{Err: ErrTurnCredencials}
+			// }
+			return nil, errors.New("TURN is not currently supported in the JavaScript/Wasm bindings")
+		}
+
+		urls = append(urls, url)
+	}
+
+	return urls, nil
+}

--- a/iceserver_test.go
+++ b/iceserver_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/js_utils.go
+++ b/js_utils.go
@@ -1,4 +1,4 @@
-// +build js
+// +build js,wasm
 
 package webrtc
 

--- a/mediaengine.go
+++ b/mediaengine.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/mediaengine_test.go
+++ b/mediaengine_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/peerconnection_go_test.go
+++ b/peerconnection_go_test.go
@@ -234,6 +234,24 @@ func TestPeerConnection_SetConfiguration_Go(t *testing.T) {
 			},
 			wantErr: &rtcerr.InvalidModificationError{Err: ErrModifyingCertificates},
 		},
+		{
+			name: "update ICEServers, no TURN credentials",
+			init: func() (*PeerConnection, error) {
+				return NewPeerConnection(Configuration{})
+			},
+			config: Configuration{
+				ICEServers: []ICEServer{
+					{
+						URLs: []string{
+							"stun:stun.l.google.com:19302",
+							"turns:google.de?transport=tcp",
+						},
+						Username: "unittest",
+					},
+				},
+			},
+			wantErr: &rtcerr.InvalidAccessError{Err: ErrNoTurnCredencials},
+		},
 	} {
 		pc, err := test.init()
 		if err != nil {

--- a/peerconnection_js.go
+++ b/peerconnection_js.go
@@ -1,4 +1,4 @@
-// +build js
+// +build js,wasm
 
 // Package webrtc implements the WebRTC 1.0 as defined in W3C WebRTC specification document.
 package webrtc
@@ -48,7 +48,6 @@ func (pc *PeerConnection) OnSignalingStateChange(f func(SignalingState)) {
 		defer oldHandler.Release()
 	}
 	onSignalingStateChangeHandler := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		// TODO(albrow): Protect args access; recover from panics.
 		state := newSignalingState(args[0].String())
 		go f(state)
 		return js.Undefined()
@@ -287,7 +286,6 @@ func (pc *PeerConnection) OnICECandidate(f func(candidate *string)) {
 		defer oldHandler.Release()
 	}
 	onICECandidateHandler := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		// TODO(albrow): Protect args access; recover from panics.
 		candidate := valueToStringPointer(args[0].Get("candidate"))
 		go f(candidate)
 		return js.Undefined()
@@ -358,9 +356,7 @@ func (pc *PeerConnection) SetIdentityProvider(provider string) (err error) {
 	return nil
 }
 
-// Note(albrow) SendRTCP is not included in MDN WebRTC documentation.
-// SendRTCP sends a user provided RTCP packet to the connected peer
-// If no peer is connected the packet is discarded
+// Note: SendRTCP is not supported.
 // func (pc *PeerConnection) SendRTCP(pkt rtcp.Packet) error {
 // 	return errors.New("Not yet implemented")
 // }
@@ -469,9 +465,7 @@ func configurationToValue(configuration Configuration) js.Value {
 		"peerIdentity":         stringToValueOrUndefined(configuration.PeerIdentity),
 		"iceCandidatePoolSize": uint8ToValueOrUndefined(configuration.ICECandidatePoolSize),
 
-		// TODO(albrow): Docs for RTCCertificate are underspecified.
-		// https://developer.mozilla.org/en-US/docs/Web/API/RTCCertificate How
-		// should we handle this?
+		// Note: Certificates are not currently supported.
 		// "certificates": configuration.Certificates,
 	})
 }
@@ -491,9 +485,9 @@ func iceServerToValue(server ICEServer) js.Value {
 	return js.ValueOf(map[string]interface{}{
 		"urls":     stringsToValue(server.URLs), // required
 		"username": stringToValueOrUndefined(server.Username),
-		// TODO(albrow): credential is not currently supported.
+		// Note: credential and credentialType are not currently supported.
 		// "credential":     interfaceToValueOrUndefined(server.Credential),
-		"credentialType": stringEnumToValueOrUndefined(server.CredentialType.String()),
+		// "credentialType": stringEnumToValueOrUndefined(server.CredentialType.String()),
 	})
 }
 
@@ -509,9 +503,7 @@ func valueToConfiguration(configValue js.Value) Configuration {
 		PeerIdentity:         valueToStringOrZero(configValue.Get("peerIdentity")),
 		ICECandidatePoolSize: valueToUint8OrZero(configValue.Get("iceCandidatePoolSize")),
 
-		// TODO(albrow): Docs for RTCCertificate are underspecified.
-		// https://developer.mozilla.org/en-US/docs/Web/API/RTCCertificate How
-		// should we handle this?
+		// Note: Certificates are not supported.
 		// Certificates []Certificate
 	}
 }
@@ -531,9 +523,9 @@ func valueToICEServer(iceServerValue js.Value) ICEServer {
 	return ICEServer{
 		URLs:     valueToStrings(iceServerValue.Get("urls")), // required
 		Username: valueToStringOrZero(iceServerValue.Get("username")),
-		// TODO(albrow): Handle Credential which might have different types.
+		// Note: Credential and CredentialType are not currently supported.
 		// Credential: iceServerValue.Get("credential"),
-		CredentialType: newICECredentialType(valueToStringOrZero(iceServerValue.Get("credentialType"))),
+		// CredentialType: newICECredentialType(valueToStringOrZero(iceServerValue.Get("credentialType"))),
 	}
 }
 

--- a/peerconnection_js_test.go
+++ b/peerconnection_js_test.go
@@ -1,4 +1,4 @@
-// +build js
+// +build js,wasm
 
 package webrtc
 

--- a/peerconnection_test.go
+++ b/peerconnection_test.go
@@ -157,24 +157,6 @@ func TestPeerConnection_SetConfiguration(t *testing.T) {
 			},
 			wantErr: &rtcerr.InvalidModificationError{Err: ErrModifyingICECandidatePoolSize},
 		},
-		{
-			name: "update ICEServers, no TURN credentials",
-			init: func() (*PeerConnection, error) {
-				return NewPeerConnection(Configuration{})
-			},
-			config: Configuration{
-				ICEServers: []ICEServer{
-					{
-						URLs: []string{
-							"stun:stun.l.google.com:19302",
-							"turns:google.de?transport=tcp",
-						},
-						Username: "unittest",
-					},
-				},
-			},
-			wantErr: &rtcerr.InvalidAccessError{Err: ErrNoTurnCredencials},
-		},
 	} {
 		pc, err := test.init()
 		if err != nil {
@@ -197,7 +179,6 @@ func TestPeerConnection_GetConfiguration(t *testing.T) {
 		ICETransportPolicy:   ICETransportPolicyAll,
 		BundlePolicy:         BundlePolicyBalanced,
 		RTCPMuxPolicy:        RTCPMuxPolicyRequire,
-		Certificates:         []Certificate{},
 		ICECandidatePoolSize: 0,
 	}
 	actual := pc.GetConfiguration()

--- a/settingengine.go
+++ b/settingengine.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (

--- a/settingengine_test.go
+++ b/settingengine_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package webrtc
 
 import (


### PR DESCRIPTION
#### Description

This includes a few small and closely related changes:

1. All occurrences of the build tag `+build js` have been changed to the
   more precise `+build js,wasm`. This will exclude the files from being
   included by third-party compilers like GopherJS, with which they are
   incompatible.
2. Some files which are incompatible with JavaScript/Wasm now have the
   correct build tag (`+build -js`) so they will be excluded from Wasm
   builds.
3. Some configuration options which are incompatible with
   JavaScript/Wasm (or at least the current bindings) will now no longer
   appear in Wasm builds. This meant creating new files with new struct
   definitions and the appropriate build tags.

#### Reference issue
Fixes #515
