### PR TITLE
Rename media.Writer AddPacket -> WriteRTP

### DIFF
--- a/examples/janus-gateway/streaming/main.go
+++ b/examples/janus-gateway/streaming/main.go
@@ -24,7 +24,7 @@ func saveToDisk(i media.Writer, track *webrtc.Track) {
 			panic(err)
 		}
 
-		if err := i.AddPacket(packet); err != nil {
+		if err := i.WriteRTP(packet); err != nil {
 			panic(err)
 		}
 	}

--- a/examples/save-to-disk/main.go
+++ b/examples/save-to-disk/main.go
@@ -26,7 +26,7 @@ func saveToDisk(i media.Writer, track *webrtc.Track) {
 		if err != nil {
 			panic(err)
 		}
-		if err := i.AddPacket(rtpPacket); err != nil {
+		if err := i.WriteRTP(rtpPacket); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/media/ivfwriter/ivfwriter.go
+++ b/pkg/media/ivfwriter/ivfwriter.go
@@ -64,8 +64,8 @@ func (i *IVFWriter) writeHeader() error {
 	return err
 }
 
-// AddPacket adds a new packet and writes the appropriate headers for it
-func (i *IVFWriter) AddPacket(packet *rtp.Packet) error {
+// WriteRTP adds a new packet and writes the appropriate headers for it
+func (i *IVFWriter) WriteRTP(packet *rtp.Packet) error {
 	if i.stream == nil {
 		return fmt.Errorf("file not opened")
 	}

--- a/pkg/media/ivfwriter/ivfwriter_test.go
+++ b/pkg/media/ivfwriter/ivfwriter_test.go
@@ -113,7 +113,7 @@ func TestIVFWriter_AddPacketAndClose(t *testing.T) {
 
 	for _, t := range addPacketTestCase {
 		if t.writer != nil {
-			res := t.writer.AddPacket(t.packet)
+			res := t.writer.WriteRTP(t.packet)
 			assert.Equal(res, t.err, t.message)
 		}
 	}

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -14,7 +14,7 @@ type Sample struct {
 // the creation of media files
 type Writer interface {
 	// Add the content of an RTP packet to the media
-	AddPacket(packet *rtp.Packet) error
+	WriteRTP(packet *rtp.Packet) error
 	// Close the media
 	// Note: Close implementation must be idempotent
 	Close() error

--- a/pkg/media/opuswriter/opuswriter.go
+++ b/pkg/media/opuswriter/opuswriter.go
@@ -140,8 +140,8 @@ func (i *OpusWriter) createPage(payload []uint8, headerType uint8, granulePos ui
 	return page
 }
 
-// AddPacket adds a new packet and writes the appropriate headers for it
-func (i *OpusWriter) AddPacket(packet *rtp.Packet) error {
+// WriteRTP adds a new packet and writes the appropriate headers for it
+func (i *OpusWriter) WriteRTP(packet *rtp.Packet) error {
 	if i.stream == nil {
 		return fmt.Errorf("file not opened")
 	}

--- a/pkg/media/opuswriter/opuswriter_test.go
+++ b/pkg/media/opuswriter/opuswriter_test.go
@@ -112,7 +112,7 @@ func TestOpusWriter_AddPacketAndClose(t *testing.T) {
 
 	for _, t := range addPacketTestCase {
 		if t.writer != nil {
-			res := t.writer.AddPacket(t.packet)
+			res := t.writer.WriteRTP(t.packet)
 			assert.Equal(t.err, res, t.message)
 		}
 	}


### PR DESCRIPTION
Makes the name consistent with webrtc's WriteRTP and makes webrtc.Track a Writer.

Fixes #556